### PR TITLE
fix: rename the library to ProjectOptions

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,10 +1,10 @@
 parse:
   additional_commands:
-    cmakelib:
+    ProjectOptions:
       pargs:
         nargs: '*'
         flags: []
-      spelling: CMakeLib
+      spelling: ProjectOptions
       kwargs:
         CLANG_WARNINGS: 1
         GCC_WARNINGS: 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cmakelib
+# ProjectOptions
 
 A general-purpose CMake library that makes using CMake easier
 
@@ -12,15 +12,15 @@ cmake_minimum_required(VERSION 3.16)
 # Set the project name to your project name, my_project isn't very descriptive
 project(myproject LANGUAGES CXX)
 
-# Add cmakelib v0.1.1
+# Add ProjectOptions v0.1.1
 include(FetchContent)
-FetchContent_Declare(cmakelib URL https://github.com/aminya/cmakelib/archive/refs/tags/v0.1.1.zip)
-FetchContent_MakeAvailable(cmakelib)
-include(${cmakelib_SOURCE_DIR}/Index.cmake)
+FetchContent_Declare(ProjectOptions URL https://github.com/aminya/ProjectOptions/archive/refs/tags/v0.1.1.zip)
+FetchContent_MakeAvailable(ProjectOptions)
+include(${ProjectOptions_SOURCE_DIR}/Index.cmake)
 
-# Initialize cmakelib
+# Initialize ProjectOptions
 # uncomment the options to enable them
-cmakelib(
+ProjectOptions(
       ENABLE_CACHE
       ENABLE_CONAN
       # WARNINGS_AS_ERRORS
@@ -49,11 +49,11 @@ target_compile_features(project_options INTERFACE cxx_std_17)
 # add your executables, libraries, etc. here:
 
 add_executable(myprogram main.cpp)
-target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect cmakelib to myprogram
+target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect ProjectOptions to myprogram
 
 ```
 
-## `cmakelib` parameters
+## `ProjectOptions` parameters
 
 - `WARNINGS_AS_ERRORS`: Treat compiler warnings as errors
 - `ENABLE_CPPCHECK`: Enable static analysis with Cppcheck
@@ -82,7 +82,7 @@ target_link_libraries(myprogram PRIVATE project_options project_warnings) # conn
 
 ⚠️ It is highly recommended to keep the build declarative and reproducible by using the function arguments as explained above.
 
-However, if you still want to change the CMake options on the fly (e.g. to enable sanitizers inside CI), you can include the `GlobalOptions.cmake`, which adds global options for the arguments of `cmakelib` function.
+However, if you still want to change the CMake options on the fly (e.g. to enable sanitizers inside CI), you can include the `GlobalOptions.cmake`, which adds global options for the arguments of `ProjectOptions` function.
 
 ```cmake
 cmake_minimum_required(VERSION 3.16)
@@ -90,18 +90,18 @@ cmake_minimum_required(VERSION 3.16)
 # Set the project name to your project name, my_project isn't very descriptive
 project(myproject LANGUAGES CXX)
 
-# Add cmakelib v0.1.1
+# Add ProjectOptions v0.1.1
 include(FetchContent)
-FetchContent_Declare(cmakelib URL https://github.com/aminya/cmakelib/archive/refs/tags/v0.1.1.zip)
-FetchContent_MakeAvailable(cmakelib)
-include(${cmakelib_SOURCE_DIR}/Index.cmake)
+FetchContent_Declare(ProjectOptions URL https://github.com/aminya/ProjectOptions/archive/refs/tags/v0.1.1.zip)
+FetchContent_MakeAvailable(ProjectOptions)
+include(${ProjectOptions_SOURCE_DIR}/Index.cmake)
 
 # Add global CMake options
-include(${cmakelib_SOURCE_DIR}/src/GlobalOptions.cmake)
+include(${ProjectOptions_SOURCE_DIR}/src/GlobalOptions.cmake)
 
-# Initialize cmakelib
+# Initialize ProjectOptions
 # uncomment the options to enable them
-cmakelib(
+ProjectOptions(
       ENABLE_CACHE
       ENABLE_CONAN
       # WARNINGS_AS_ERRORS
@@ -128,5 +128,5 @@ target_compile_features(project_options INTERFACE cxx_std_17)
 # add your executables, libraries, etc. here:
 
 add_executable(myprogram main.cpp)
-target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect cmakelib to myprogram
+target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect ProjectOptions to myprogram
 ```

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -45,7 +45,7 @@ macro(run_conan)
       PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}
       BUILD missing
             # Pass compile-time configured options into conan
-      OPTIONS ${cmakelib_CONAN_OPTIONS}
+      OPTIONS ${ProjectOptions_CONAN_OPTIONS}
       SETTINGS ${settings})
   endforeach()
 

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKELIB_SRC_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE FILEPATH "")
+set(ProjectOptions_SRC_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE FILEPATH "")
 
-include("${CMAKELIB_SRC_DIR}/PreventInSourceBuilds.cmake")
+include("${ProjectOptions_SRC_DIR}/PreventInSourceBuilds.cmake")
 
 #
 # Params:
@@ -29,8 +29,8 @@ include("${CMAKELIB_SRC_DIR}/PreventInSourceBuilds.cmake")
 # - GCC_WARNINGS: Override the defaults for the GCC warnings
 # - CONAN_OPTIONS: Extra Conan options
 #
-# NOTE: cmake-lint [C0103] Invalid macro name "cmakelib" doesn't match `[0-9A-Z_]+`
-macro(cmakelib)
+# NOTE: cmake-lint [C0103] Invalid macro name "ProjectOptions" doesn't match `[0-9A-Z_]+`
+macro(ProjectOptions)
   set(options
       WARNINGS_AS_ERRORS
       ENABLE_COVERAGE
@@ -56,16 +56,16 @@ macro(cmakelib)
       GCC_WARNINGS)
   set(multiValueArgs CONAN_OPTIONS)
   cmake_parse_arguments(
-    cmakelib
+    ProjectOptions
     "${options}"
     "${oneValueArgs}"
     "${multiValueArgs}"
     ${ARGN})
 
-  include("${CMAKELIB_SRC_DIR}/StandardProjectSettings.cmake")
+  include("${ProjectOptions_SRC_DIR}/StandardProjectSettings.cmake")
 
-  if(${cmakelib_ENABLE_IPO})
-    include("${CMAKELIB_SRC_DIR}/InterproceduralOptimization.cmake")
+  if(${ProjectOptions_ENABLE_IPO})
+    include("${ProjectOptions_SRC_DIR}/InterproceduralOptimization.cmake")
     enable_ipo()
   endif()
 
@@ -73,7 +73,7 @@ macro(cmakelib)
   add_library(project_options INTERFACE)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    if(cmakelib_ENABLE_BUILD_WITH_TIME_TRACE)
+    if(ProjectOptions_ENABLE_BUILD_WITH_TIME_TRACE)
       target_compile_options(project_options INTERFACE -ftime-trace)
     endif()
   endif()
@@ -81,64 +81,64 @@ macro(cmakelib)
   # Link this 'library' to use the warnings specified in CompilerWarnings.cmake
   add_library(project_warnings INTERFACE)
 
-  if(${cmakelib_ENABLE_CACHE})
+  if(${ProjectOptions_ENABLE_CACHE})
     # enable cache system
-    include("${CMAKELIB_SRC_DIR}/Cache.cmake")
+    include("${ProjectOptions_SRC_DIR}/Cache.cmake")
     enable_cache()
   endif()
 
-  if(${cmakelib_ENABLE_USER_LINKER})
+  if(${ProjectOptions_ENABLE_USER_LINKER})
     # Add linker configuration
-    include("${CMAKELIB_SRC_DIR}/Linker.cmake")
+    include("${ProjectOptions_SRC_DIR}/Linker.cmake")
     configure_linker(project_options)
   endif()
 
   # standard compiler warnings
-  include("${CMAKELIB_SRC_DIR}/CompilerWarnings.cmake")
+  include("${ProjectOptions_SRC_DIR}/CompilerWarnings.cmake")
   set_project_warnings(
     project_warnings
-    WARNINGS_AS_ERRORS=${cmakelib_WARNINGS_AS_ERRORS}
-    MSVC_WARNINGS=${cmakelib_MSVC_WARNINGS}
-    CLANG_WARNINGS=${cmakelib_CLANG_WARNINGS}
-    GCC_WARNINGS=${cmakelib_GCC_WARNINGS})
+    WARNINGS_AS_ERRORS=${ProjectOptions_WARNINGS_AS_ERRORS}
+    MSVC_WARNINGS=${ProjectOptions_MSVC_WARNINGS}
+    CLANG_WARNINGS=${ProjectOptions_CLANG_WARNINGS}
+    GCC_WARNINGS=${ProjectOptions_GCC_WARNINGS})
 
-  include("${CMAKELIB_SRC_DIR}/Tests.cmake")
-  if(${cmakelib_ENABLE_COVERAGE})
+  include("${ProjectOptions_SRC_DIR}/Tests.cmake")
+  if(${ProjectOptions_ENABLE_COVERAGE})
     enable_coverage(${PROJECT_NAME})
   endif()
 
   # sanitizer options if supported by compiler
-  include("${CMAKELIB_SRC_DIR}/Sanitizers.cmake")
+  include("${ProjectOptions_SRC_DIR}/Sanitizers.cmake")
   enable_sanitizers(
     project_options
-    ${cmakelib_ENABLE_SANITIZER_ADDRESS}
-    ${cmakelib_ENABLE_SANITIZER_LEAK}
-    ${cmakelib_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}
-    ${cmakelib_ENABLE_SANITIZER_THREAD}
-    ${cmakelib_ENABLE_SANITIZER_MEMORY})
+    ${ProjectOptions_ENABLE_SANITIZER_ADDRESS}
+    ${ProjectOptions_ENABLE_SANITIZER_LEAK}
+    ${ProjectOptions_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}
+    ${ProjectOptions_ENABLE_SANITIZER_THREAD}
+    ${ProjectOptions_ENABLE_SANITIZER_MEMORY})
 
-  if(${cmakelib_ENABLE_DOXYGEN})
+  if(${ProjectOptions_ENABLE_DOXYGEN})
     # enable doxygen
-    include("${CMAKELIB_SRC_DIR}/Doxygen.cmake")
+    include("${ProjectOptions_SRC_DIR}/Doxygen.cmake")
     enable_doxygen()
   endif()
 
   # allow for static analysis options
-  include("${CMAKELIB_SRC_DIR}/StaticAnalyzers.cmake")
-  if(${cmakelib_ENABLE_CPPCHECK})
+  include("${ProjectOptions_SRC_DIR}/StaticAnalyzers.cmake")
+  if(${ProjectOptions_ENABLE_CPPCHECK})
     enable_cppcheck()
   endif()
 
-  if(${cmakelib_ENABLE_CLANG_TIDY})
+  if(${ProjectOptions_ENABLE_CLANG_TIDY})
     enable_clang_tidy()
   endif()
 
-  if(${cmakelib_ENABLE_INCLUDE_WHAT_YOU_USE})
+  if(${ProjectOptions_ENABLE_INCLUDE_WHAT_YOU_USE})
     enable_include_what_you_use()
   endif()
 
   # Very basic PCH example
-  if(${cmakelib_ENABLE_PCH})
+  if(${ProjectOptions_ENABLE_PCH})
     # This sets a global PCH parameter, each project will build its own PCH, which is a good idea if any #define's change
     #
     # consider breaking this out per project as necessary
@@ -151,12 +151,12 @@ macro(cmakelib)
       <utility>)
   endif()
 
-  if(${cmakelib_ENABLE_CONAN})
-    include("${CMAKELIB_SRC_DIR}/Conan.cmake")
+  if(${ProjectOptions_ENABLE_CONAN})
+    include("${ProjectOptions_SRC_DIR}/Conan.cmake")
     run_conan()
   endif()
 
-  if(${cmakelib_ENABLE_UNITY})
+  if(${ProjectOptions_ENABLE_UNITY})
     # Add for any project you want to apply unity builds for
     set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,18 +5,18 @@ project(
   VERSION 0.1.0
   LANGUAGES CXX)
 
-### Add cmakelib
+### Add ProjectOptions
 # include(FetchContent)
-# FetchContent_Declare(cmakelib URL https://github.com/aminya/cmakelib/archive/refs/heads/main.zip)
-# FetchContent_MakeAvailable(cmakelib)
-# include(${cmakelib_SOURCE_DIR}/Index.cmake)
+# FetchContent_Declare(ProjectOptions URL https://github.com/aminya/ProjectOptions/archive/refs/heads/main.zip)
+# FetchContent_MakeAvailable(ProjectOptions)
+# include(${ProjectOptions_SOURCE_DIR}/Index.cmake)
 include(../src/Index.cmake)
 
 add_library(escape INTERFACE)
 
-# Initialize cmakelib
+# Initialize ProjectOptions
 # uncomment the options to enable them
-CMakeLib(
+ProjectOptions(
   ENABLE_CACHE
   # ENABLE_CONAN
   # WARNINGS_AS_ERRORS
@@ -37,7 +37,7 @@ CMakeLib(
   # ENABLE_SANITIZER_MEMORY
 )
 
-# NOTE: project_options and project_warnings are defined inside cmakelib
+# NOTE: project_options and project_warnings are defined inside ProjectOptions
 target_compile_features(project_options INTERFACE cxx_std_17)
 target_link_libraries(escape INTERFACE project_options project_warnings)
 


### PR DESCRIPTION
BREAKING CHANGE cmakelib is renamed to ProjectOptions

Fixes #5 