### PR TITLE
Allow project options to be used in creation of a conan package. 

### DIFF
--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -34,8 +34,7 @@ macro(run_conan)
     https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
   if(CONAN_EXPORTED)
-    #standard conan installation, deps will be defined in conanfile and not necessary 
-    # to call conan again, conan is alreay running.
+    # standard conan installation, in which deps will be defined in conanfile. It is not necessary to call conan again, as it is already running.
     include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
     conan_basic_setup()
   else()

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -33,46 +33,53 @@ macro(run_conan)
     URL
     https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
-  # For multi configuration generators, like VS and XCode
-  if(NOT CMAKE_CONFIGURATION_TYPES)
-    message(STATUS "Single configuration build!")
-    set(LIST_OF_BUILD_TYPES ${CMAKE_BUILD_TYPE})
+  if(CONAN_EXPORTED)
+    #standard conan installation, deps will be defined in conanfile and not necessary 
+    # to call conan again, conan is alreay running.
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
   else()
-    message(STATUS "Multi-configuration build: '${CMAKE_CONFIGURATION_TYPES}'!")
-    set(LIST_OF_BUILD_TYPES ${CMAKE_CONFIGURATION_TYPES})
+    # For multi configuration generators, like VS and XCode
+    if(NOT CMAKE_CONFIGURATION_TYPES)
+      message(STATUS "Single configuration build!")
+      set(LIST_OF_BUILD_TYPES ${CMAKE_BUILD_TYPE})
+    else()
+      message(STATUS "Multi-configuration build: '${CMAKE_CONFIGURATION_TYPES}'!")
+      set(LIST_OF_BUILD_TYPES ${CMAKE_CONFIGURATION_TYPES})
+    endif()
+
+    is_verbose(_is_verbose)
+    if(NOT ${_is_verbose})
+      set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+      set(OUTPUT_QUIET OFF)
+    endif()
+
+    foreach(TYPE ${LIST_OF_BUILD_TYPES})
+      message(STATUS "Running Conan for build type '${TYPE}'")
+
+      # Detects current build settings to pass into conan
+      conan_cmake_autodetect(settings BUILD_TYPE ${TYPE})
+
+      # PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR} is used to tell conan to process
+      # the external "conanfile.py" provided with the project
+      # Alternatively a conanfile.txt could be used
+      conan_cmake_install(
+        PATH_OR_REFERENCE
+        ${CMAKE_SOURCE_DIR}
+        BUILD
+        missing
+        # Pass compile-time configured options into conan
+        OPTIONS
+        ${ProjectOptions_CONAN_OPTIONS}
+        # Pass CMake compilers to Conan
+        ENV
+        "CC=${CMAKE_C_COMPILER}"
+        "CXX=${CMAKE_CXX_COMPILER}"
+        SETTINGS
+        ${settings}
+        ${OUTPUT_QUIET})
+    endforeach()
   endif()
-
-  is_verbose(_is_verbose)
-  if(NOT ${_is_verbose})
-    set(OUTPUT_QUIET "OUTPUT_QUIET")
-  else()
-    set(OUTPUT_QUIET OFF)
-  endif()
-
-  foreach(TYPE ${LIST_OF_BUILD_TYPES})
-    message(STATUS "Running Conan for build type '${TYPE}'")
-
-    # Detects current build settings to pass into conan
-    conan_cmake_autodetect(settings BUILD_TYPE ${TYPE})
-
-    # PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR} is used to tell conan to process
-    # the external "conanfile.py" provided with the project
-    # Alternatively a conanfile.txt could be used
-    conan_cmake_install(
-      PATH_OR_REFERENCE
-      ${CMAKE_SOURCE_DIR}
-      BUILD
-      missing
-      # Pass compile-time configured options into conan
-      OPTIONS
-      ${ProjectOptions_CONAN_OPTIONS}
-      # Pass CMake compilers to Conan
-      ENV
-      "CC=${CMAKE_C_COMPILER}"
-      "CXX=${CMAKE_CXX_COMPILER}"
-      SETTINGS
-      ${settings}
-      ${OUTPUT_QUIET})
-  endforeach()
 
 endmacro()

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -35,7 +35,11 @@ macro(run_conan)
 
   if(CONAN_EXPORTED)
     # standard conan installation, in which deps will be defined in conanfile. It is not necessary to call conan again, as it is already running.
-    include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+    if (EXISTS "${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake")
+      include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+    else()
+       message(FATAL_ERROR "Could not set up conan because \"${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake\" does not exist")
+    endif()
     conan_basic_setup()
   else()
     # For multi configuration generators, like VS and XCode

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -36,7 +36,7 @@ macro(run_conan)
   if(CONAN_EXPORTED)
     #standard conan installation, deps will be defined in conanfile and not necessary 
     # to call conan again, conan is alreay running.
-    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
     conan_basic_setup()
   else()
     # For multi configuration generators, like VS and XCode


### PR DESCRIPTION
Stumbled across this problem when using project options to build a library, that library could no longer be built via a conan recipe.

i have wrapped part of the conan.cmake to test if we are been built via ``conan`` and allow conan to define the build settings, rather than call ''conan_cmake_autodetect`` 

you can find my test project [library](https://github.com/lambtonr/conan_library) and [recipe](https://github.com/lambtonr/conan_recipe) that shows the problem (currently calling my fork of project options) reverting back to current release should show the following issue.

gcc ``conan create ./all 0.0.1@lambtonr/testing``
```sh
[ 50%] Building CXX object CMakeFiles/example.dir/example.cpp.o
[100%] Linking CXX executable bin/example
[100%] Built target example
HelloWorld/0.0.1@lambtonr/testing (test package): Running test()
Hello World! Release!
```

clang ``conan create ./all 0.0.1@lambtonr/testing``
```sh
[ 50%] Building CXX object CMakeFiles/example.dir/example.cpp.o
[100%] Linking CXX executable bin/example
CMakeFiles/example.dir/example.cpp.o: In function `main':
example.cpp:(.text+0xd): undefined reference to `ConanLibrary::HelloWorld()'
```
This is caused by the fact ``conan_cmake_autodetect`` will use different setting to conan GCC default profile matches that of ``conan_cmake_autodetect`` where as clangs defaults differ causing the issue.

```sh 
Configuration: (conan profile show default)
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=clang
compiler.libcxx=libstdc++
compiler.version=13
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

....

Configuration: (conan_cmake_autodetect)
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=clang
compiler.cppstd=11
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux
os_build=Linux
[options]
[build_requires]
[env]
CC=
CXX=/usr/bin/clang++
```
