### PR TITLE
fix: set the fallbacks of the RelWithDebInfo Colcon build in the cache

### DIFF
--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -50,7 +50,9 @@ macro(common_project_options)
      ""
      OR "$ENV{COLCON}" STREQUAL "1")
     # these are used in order:
-    set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release;None;NoConfig")
+    set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO
+        "RelWithDebInfo;Release;None;NoConfig"
+        CACHE STRING "Fallbacks for the RelWithDebInfo build type")
   endif()
 
   # Generate compile_commands.json to make it easier to work with clang based tools


### PR DESCRIPTION
Previously this only fixed the immediate build scope and not the whole build