### PR TITLE
Forcing Conan build type to match CMake one

### DIFF
--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -69,7 +69,7 @@ macro(run_conan)
         set(CONAN_ENV ENV "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}")
       else()
         # Derive all conan settings from a conan profile
-        set(CONAN_SETTINGS PROFILE ${ProjectOptions_CONAN_PROFILE})
+        set(CONAN_SETTINGS PROFILE ${ProjectOptions_CONAN_PROFILE} SETTINGS "build_type=${TYPE}")
         # CONAN_ENV should be redundant, since the profile can set CC & CXX
       endif()
 


### PR DESCRIPTION
Invoking Conan with `-s build_type=` parameter matching active CMake build type, or all the active ones if in multi-config scenario.

This allows CMake to correctly build targets and link to correct Conan-insatlled dependencies.