### PR TITLE
prevent use of ProjectOptions_SRC_DIR as cache var

### DIFF
--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -69,7 +69,11 @@ macro(run_conan)
         set(CONAN_ENV ENV "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}")
       else()
         # Derive all conan settings from a conan profile
-        set(CONAN_SETTINGS PROFILE ${ProjectOptions_CONAN_PROFILE} SETTINGS "build_type=${TYPE}")
+        set(CONAN_SETTINGS
+            PROFILE
+            ${ProjectOptions_CONAN_PROFILE}
+            SETTINGS
+            "build_type=${TYPE}")
         # CONAN_ENV should be redundant, since the profile can set CC & CXX
       endif()
 

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -10,15 +10,13 @@ endif()
 
 include_guard()
 
-set(ProjectOptions_SRC_DIR ${CMAKE_CURRENT_LIST_DIR})
-set(ProjectOptions_SOURCE_DIR
+set(ProjectOptions_SRC_DIR
     ${CMAKE_CURRENT_LIST_DIR}
     PARENT_SCOPE)
 
 # include the files to allow calling individual functions (including the files does not run any code.)
 include("${CMAKE_CURRENT_LIST_DIR}/Common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
-# see below! include("${CMAKE_CURRENT_LIST_DIR}/Vcpkg.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/SystemLink.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/Cuda.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/PackageProject.cmake")

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -18,7 +18,7 @@ set(ProjectOptions_SOURCE_DIR
 # include the files to allow calling individual functions (including the files does not run any code.)
 include("${CMAKE_CURRENT_LIST_DIR}/Common.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/Vcpkg.cmake")
+# see below! include("${CMAKE_CURRENT_LIST_DIR}/Vcpkg.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/SystemLink.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/Cuda.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/PackageProject.cmake")

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -10,34 +10,35 @@ endif()
 
 include_guard()
 
-set(ProjectOptions_SRC_DIR
+set(ProjectOptions_SRC_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(ProjectOptions_SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}
-    CACHE FILEPATH "")
+    PARENT_SCOPE)
 
 # include the files to allow calling individual functions (including the files does not run any code.)
-include("${ProjectOptions_SRC_DIR}/Common.cmake")
-include("${ProjectOptions_SRC_DIR}/Utilities.cmake")
-include("${ProjectOptions_SRC_DIR}/Vcpkg.cmake")
-include("${ProjectOptions_SRC_DIR}/SystemLink.cmake")
-include("${ProjectOptions_SRC_DIR}/Cuda.cmake")
-include("${ProjectOptions_SRC_DIR}/PackageProject.cmake")
-include("${ProjectOptions_SRC_DIR}/Optimization.cmake")
-include("${ProjectOptions_SRC_DIR}/Cache.cmake")
-include("${ProjectOptions_SRC_DIR}/Linker.cmake")
-include("${ProjectOptions_SRC_DIR}/CompilerWarnings.cmake")
-include("${ProjectOptions_SRC_DIR}/Tests.cmake")
-include("${ProjectOptions_SRC_DIR}/Sanitizers.cmake")
-include("${ProjectOptions_SRC_DIR}/Doxygen.cmake")
-include("${ProjectOptions_SRC_DIR}/StaticAnalyzers.cmake")
-include("${ProjectOptions_SRC_DIR}/VCEnvironment.cmake")
-include("${ProjectOptions_SRC_DIR}/MinGW.cmake")
-include("${ProjectOptions_SRC_DIR}/DetectCompiler.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Vcpkg.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/SystemLink.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Cuda.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PackageProject.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Optimization.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Cache.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Linker.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/CompilerWarnings.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Tests.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Sanitizers.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Doxygen.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/StaticAnalyzers.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/VCEnvironment.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/MinGW.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/DetectCompiler.cmake")
 
 # Include msvc toolchain on windows if the generator is not visual studio. Should be called before run_vcpkg and run_conan to be effective
 msvc_toolchain()
 
-include("${ProjectOptions_SRC_DIR}/Conan.cmake")
-include("${ProjectOptions_SRC_DIR}/Vcpkg.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Conan.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Vcpkg.cmake")
 
 #
 # Params:

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -10,9 +10,8 @@ endif()
 
 include_guard()
 
-set(ProjectOptions_SRC_DIR
-    ${CMAKE_CURRENT_LIST_DIR}
-    PARENT_SCOPE)
+# only useable here
+set(ProjectOptions_SRC_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # include the files to allow calling individual functions (including the files does not run any code.)
 include("${CMAKE_CURRENT_LIST_DIR}/Common.cmake")

--- a/src/StaticAnalyzers.cmake
+++ b/src/StaticAnalyzers.cmake
@@ -159,7 +159,6 @@ macro(enable_include_what_you_use)
   endif()
 endmacro()
 
-
 # Disable clang-tidy for target
 macro(target_disable_clang_tidy TARGET)
   find_program(CLANGTIDY clang-tidy)
@@ -183,17 +182,18 @@ macro(target_disable_vs_analysis TARGET)
   if(CMAKE_GENERATOR MATCHES "Visual Studio")
     set_target_properties(
       ${TARGET}
-      PROPERTIES
-        VS_GLOBAL_EnableMicrosoftCodeAnalysis false
-        VS_GLOBAL_CodeAnalysisRuleSet ""
-        VS_GLOBAL_EnableClangTidyCodeAnalysis ""
-    )
+      PROPERTIES VS_GLOBAL_EnableMicrosoftCodeAnalysis false
+                 VS_GLOBAL_CodeAnalysisRuleSet ""
+                 VS_GLOBAL_EnableClangTidyCodeAnalysis "")
   endif()
 endmacro()
 
 # Disable static analysis for target
 macro(target_disable_static_analysis TARGET)
-  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+  if(NOT
+     CMAKE_GENERATOR
+     MATCHES
+     "Visual Studio")
     target_disable_clang_tidy(${TARGET})
     target_disable_cpp_check(${TARGET})
   endif()

--- a/src/VCEnvironment.cmake
+++ b/src/VCEnvironment.cmake
@@ -1,6 +1,6 @@
 include_guard()
 
-include("${ProjectOptions_SRC_DIR}/Utilities.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
 
 # detect if the compiler is msvc
 function(is_msvc value)


### PR DESCRIPTION
if to project **A** and **B** use different version of `project_options` and
project **C** use A and B with `CMP.cmake` (_FetchContents_), there is a common `CMakeCache` variable used!