### PR TITLE
fix: require CMake 3.20 as the minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,14 @@ jobs:
             vcvarsall: true
           - os: "windows-2022"
             compiler: "msvc"
-            cmake: 3.18.0
             cmake_generator: "Ninja"
             vcvarsall: true
           - os: "windows-2022"
             compiler: "msvc"
-            cmake: 3.18.0
             cmake_generator: "Ninja"
             vcvarsall: false
           - os: "windows-2022"
             compiler: "msvc"
-            cmake: 3.18.0
             vcvarsall: false
     steps:
       - uses: actions/checkout@v2

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -1,12 +1,6 @@
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-  cmake_minimum_required(VERSION 3.18)
-else()
-  cmake_minimum_required(VERSION 3.16)
-  message(
-    WARNING
-      "Consider upgrading CMake to the latest version. CMake ${CMAKE_VERSION} might fail in the linking stage because of missing references."
-  )
-endif()
+cmake_minimum_required(VERSION 3.20)
+# 3.20 is required by the windows toolchain and cmake_path. It also has a more reliable building functionality.
+# 3.18 required by package_project and interprocedural optimization. It also has a more reliable building functionality (no errors during the linking stage).
 
 include_guard()
 

--- a/src/Optimization.cmake
+++ b/src/Optimization.cmake
@@ -1,29 +1,22 @@
 include_guard()
 
 macro(enable_interprocedural_optimization project_name)
-  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-      include(CheckIPOSupported)
-      check_ipo_supported(RESULT result OUTPUT output)
-      is_mingw(_is_mingw)
-      if(result AND NOT ${_is_mingw})
-        # If a static library of this project is used in another project that does not have `CMAKE_INTERPROCEDURAL_OPTIMIZATION` enabled, a linker error might happen.
-        # TODO set this option in `package_project` function.
-        message(
-          STATUS
-            "Interprocedural optimization is enabled. In other projects, linking with the compiled libraries of this project might require `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)`"
-        )
-        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-        set_target_properties(${project_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
-      else()
-        message(WARNING "Interprocedural Optimization is not supported. Not using it. Here is the error log: ${output}")
-      endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT result OUTPUT output)
+    is_mingw(_is_mingw)
+    if(result AND NOT ${_is_mingw})
+      # If a static library of this project is used in another project that does not have `CMAKE_INTERPROCEDURAL_OPTIMIZATION` enabled, a linker error might happen.
+      # TODO set this option in `package_project` function.
+      message(
+        STATUS
+          "Interprocedural optimization is enabled. In other projects, linking with the compiled libraries of this project might require `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)`"
+      )
+      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+      set_target_properties(${project_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+      message(WARNING "Interprocedural Optimization is not supported. Not using it. Here is the error log: ${output}")
     endif()
-  else()
-    message(
-      WARNING
-        "Consider upgrading CMake to the latest version. CMake ${CMAKE_VERSION} does not support ENABLE_INTERPROCEDURAL_OPTIMIZATION."
-    )
   endif()
 endmacro()
 

--- a/src/PackageProject.cmake
+++ b/src/PackageProject.cmake
@@ -5,18 +5,8 @@ include_guard()
 # A function that packages the project for external usage (e.g. from vcpkg, Conan, etc).
 # See the [README.md] for more details
 function(package_project)
-  if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
-    message(
-      WARNING
-        "Consider upgrading CMake to the latest version. CMake ${CMAKE_VERSION} does not support checking for policy CMP0103."
-    )
-  else()
-    cmake_minimum_required(VERSION 3.18)
-    cmake_policy(SET CMP0103 NEW) # disallow multiple calls with the same NAME
-  endif()
-
-  set(_options ARCH_INDEPENDENT # default to false
-  )
+  # default to false
+  set(_options ARCH_INDEPENDENT)
   set(_oneValueArgs
       # default to the project_name:
       NAME

--- a/src/SystemLink.cmake
+++ b/src/SystemLink.cmake
@@ -12,7 +12,8 @@ function(target_include_system_directories target)
 
   foreach(scope IN ITEMS INTERFACE PUBLIC PRIVATE)
     foreach(lib_include_dirs IN LISTS ARG_${scope})
-      if(NOT MSVC OR (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "19.29.30036.3"))
+      if(NOT MSVC OR (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL
+                                                                       "19.29.30036.3"))
         # system includes do not work prior to CMake 3.24.0 and MSVC 19.29.30036.3
         set(_SYSTEM SYSTEM)
       endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,10 +117,7 @@ target_link_system_libraries(
   PRIVATE
   fmt::fmt
   Eigen3::Eigen)
-target_link_system_libraries(
-  lib2
-  PRIVATE
-  mythirdpartylib)
+target_link_system_libraries(lib2 PRIVATE mythirdpartylib)
 
 # package everything automatically
 package_project(

--- a/test/include/mylib/lib.hpp
+++ b/test/include/mylib/lib.hpp
@@ -18,13 +18,13 @@
 #include <cstring>
 
 int some_fun() {
-    fmt::print("Hello from fmt{}", "!");
+  fmt::print("Hello from fmt{}", "!");
 
-    // populate an Eigen vector with the values
-    auto eigen_vec = Eigen::VectorXd::LinSpaced(10, 0, 1);
+  // populate an Eigen vector with the values
+  auto eigen_vec = Eigen::VectorXd::LinSpaced(10, 0, 1);
 
-    // print the vector
-    fmt::print("{}", eigen_vec);
+  // print the vector
+  fmt::print("{}", eigen_vec);
 
-    return 0;
+  return 0;
 }

--- a/test/libs/mythirdpartylib/CMakeLists.txt
+++ b/test/libs/mythirdpartylib/CMakeLists.txt
@@ -1,11 +1,6 @@
-
 add_library(mythirdpartylib STATIC src/Foo.cpp)
 generate_export_header(mythirdpartylib)
 
-target_include_directories(mythirdpartylib
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-target_include_directories(mythirdpartylib
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-)
+target_include_directories(mythirdpartylib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:include>)
+target_include_directories(mythirdpartylib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)

--- a/test/libs/mythirdpartylib/include/Foo.hpp
+++ b/test/libs/mythirdpartylib/include/Foo.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "mythirdpartylib_export.h"
 
@@ -9,17 +9,17 @@ namespace mythirdpartylib {
 
 class MYTHIRDPARTYLIB_EXPORT Foo {
 public:
-    Foo() = default;
+  Foo() = default;
 
-    /*implicit*/ Foo(int a) : m_a(a) {}
+  /*implicit*/ Foo(int a) : m_a(a) {}
 
-    int a() const { return m_a; }
+  int a() const { return m_a; }
 
-    void update(bool b, bool c, bool d);
-    void bad(std::vector<std::string>& v);
+  void update(bool b, bool c, bool d);
+  void bad(std::vector<std::string> &v);
 
 private:
-    int m_a;
+  int m_a;
 };
 
-}
+} // namespace mythirdpartylib

--- a/test/libs/mythirdpartylib/src/Foo.cpp
+++ b/test/libs/mythirdpartylib/src/Foo.cpp
@@ -3,22 +3,22 @@
 namespace mythirdpartylib {
 
 void Foo::update(bool b, bool c, bool d) {
-    int e = b + d;
-    m_a = e;
+  int e = b + d;
+  m_a = e;
 }
 
-void Foo::bad(std::vector<std::string>& v) {
-    std::string val = "hello";
-    int index = -1;                    // bad, plus should use gsl::index
-    for (int i = 0; i < v.size(); ++i) {
-        if (v[i] == val) {
-            index = i;
-            break;
-        }
+void Foo::bad(std::vector<std::string> &v) {
+  std::string val = "hello";
+  int index = -1; // bad, plus should use gsl::index
+  for (int i = 0; i < v.size(); ++i) {
+    if (v[i] == val) {
+      index = i;
+      break;
     }
+  }
 }
 
-static Foo foo (5);
+static Foo foo(5);
 static Foo bar = 42;
 
-}
+} // namespace mythirdpartylib

--- a/test/src/main/main.cpp
+++ b/test/src/main/main.cpp
@@ -16,20 +16,20 @@
 #include <cstring>
 
 int main() {
-    fmt::print("Hello from fmt{}", "!");
+  fmt::print("Hello from fmt{}", "!");
 
-    Eigen::VectorXd eigen_vec = Eigen::Vector3d(1, 2, 3);
-    fmt::print("{}", eigen_vec);
+  Eigen::VectorXd eigen_vec = Eigen::Vector3d(1, 2, 3);
+  fmt::print("{}", eigen_vec);
 
-#if !defined(__MINGW32__) && !defined(__MSYS__)// TODO fails
-    Eigen::VectorXd eigen_vec2 = Eigen::VectorXd::LinSpaced(10, 0, 1);
-    fmt::print("{}", eigen_vec2);
+#if !defined(__MINGW32__) && !defined(__MSYS__) // TODO fails
+  Eigen::VectorXd eigen_vec2 = Eigen::VectorXd::LinSpaced(10, 0, 1);
+  fmt::print("{}", eigen_vec2);
 #endif
 
-    // trigger address sanitizer
-    // int *p = nullptr;
-    // *p = 1;
+  // trigger address sanitizer
+  // int *p = nullptr;
+  // *p = 1;
 
-    // trigger compiler warnings, clang-tidy, and cppcheck
-    int a;
+  // trigger compiler warnings, clang-tidy, and cppcheck
+  int a;
 }

--- a/test/src/mylib2/lib.cpp
+++ b/test/src/mylib2/lib.cpp
@@ -16,15 +16,15 @@
 #include <cstring>
 
 int some_fun2() {
-    fmt::print("Hello from fmt{}", "!");
+  fmt::print("Hello from fmt{}", "!");
 
-    Eigen::VectorXd eigen_vec = Eigen::Vector3d(1, 2, 3);
-    fmt::print("{}", eigen_vec);
+  Eigen::VectorXd eigen_vec = Eigen::Vector3d(1, 2, 3);
+  fmt::print("{}", eigen_vec);
 
-#if !defined(__MINGW32__) && !defined(__MSYS__)// TODO fails
-    Eigen::VectorXd eigen_vec2 = Eigen::VectorXd::LinSpaced(10, 0, 1);
-    fmt::print("{}", eigen_vec2);
+#if !defined(__MINGW32__) && !defined(__MSYS__) // TODO fails
+  Eigen::VectorXd eigen_vec2 = Eigen::VectorXd::LinSpaced(10, 0, 1);
+  fmt::print("{}", eigen_vec2);
 #endif
 
-    return 0;
+  return 0;
 }

--- a/test_install/src/another_main.cpp
+++ b/test_install/src/another_main.cpp
@@ -2,6 +2,6 @@
 #include <mylib2/lib.hpp>
 
 int main() {
-    some_fun2();
-    return some_fun2();
+  some_fun2();
+  return some_fun2();
 }


### PR DESCRIPTION
- 3.20 is required by the windows toolchain and cmake_path. It also has a more reliable building functionality.
- 3.18 required by package_project and interprocedural optimization. It also has a more reliable building functionality (no errors during the linking stage).

Installing a new CMake version is very easy using [setup-cpp](https://github.com/aminya/setup-cpp/) or other methods like `pip`
