### PR TITLE
feat: create a symlink of `complie_commands.json` on the source dir

### DIFF
--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -99,13 +99,13 @@ macro(common_project_options)
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
     endif()
 
-    # Add `compile_commans.json` to `.gitignore` if `.gitignore` exists
+    # Add compile_commans.json to .gitignore if .gitignore exists
     set(GITIGNORE_FILE "${CMAKE_SOURCE_DIR}/.gitignore")
     if(EXISTS ${GITIGNORE_FILE})
       file(STRINGS ${GITIGNORE_FILE} HAS_IGNORED REGEX "^compile_commands.json")
 
       if(NOT HAS_IGNORED)
-        message(STATUS "Adding `compile_commands.json` to `.gitignore`")
+        message(STATUS "Adding compile_commands.json to .gitignore")
         file(APPEND ${GITIGNORE_FILE} "\ncompile_commands.json")
       endif()
     endif()

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -76,12 +76,9 @@ macro(common_project_options)
     # Make a symbol link of compile_commands.json on the source dir to help clang based tools find it
     if(WIN32)
       # Detect whether cmake is run as administrator (only administrator can read the LOCAL SERVICE account reg key)
-      cmake_host_system_information(RESULT IS_ADMINISTRATOR QUERY WINDOWS_REGISTRY "HKU\\S-1-5-19")
+      cmake_host_system_information(RESULT QURY_RESULT QUERY WINDOWS_REGISTRY "HKU\\S-1-5-19" ERROR_VARIABLE IS_NONADMINISTRATOR)
 
-      if(IS_ADMINISTRATOR)
-        # For administrator, symlink is available
-        file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
-      else()
+      if(IS_NONADMINISTRATOR)
         # For non-administrator, create an auxiliary target and ask user to run it
         add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
           COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
@@ -93,6 +90,9 @@ macro(common_project_options)
           VERBATIM
         )
         message(AUTHOR_WARNING "Can't symlink compile_commands.json. Run cmake as administrator or use `cmake --build <build_dir> -t _copy_compile_commands` to copy it.")
+      else()
+        # For administrator, symlink is available
+        file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
       endif()
     else()
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -86,14 +86,14 @@ macro(common_project_options)
 
     if(IS_NONADMINISTRATOR)
       # For non-administrator, create an auxiliary target and ask user to run it
-      add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
-        VERBATIM
+      add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
+          COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
+          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+          VERBATIM
       )
       add_custom_target(_copy_compile_commands
-        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
-        VERBATIM
+          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+          VERBATIM
       )
       message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
     else()

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -100,7 +100,7 @@ macro(common_project_options)
       message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
     else()
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
-      message(STATUS "compile_commands.json was symlinked to the root.")
+      message(TRACE "compile_commands.json was symlinked to the root.")
     endif()
 
     # Add compile_commans.json to .gitignore if .gitignore exists
@@ -110,7 +110,7 @@ macro(common_project_options)
       file(STRINGS ${GITIGNORE_FILE} HAS_IGNORED REGEX "^compile_commands.json")
 
       if(NOT HAS_IGNORED)
-        message(STATUS "Adding compile_commands.json to .gitignore")
+        message(TRACE "Adding compile_commands.json to .gitignore")
         file(APPEND ${GITIGNORE_FILE} "\ncompile_commands.json")
       endif()
     endif()

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -89,13 +89,13 @@ macro(common_project_options)
     if(IS_NONADMINISTRATOR)
       # For non-administrator, create an auxiliary target and ask user to run it
       add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
-          COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
-          VERBATIM
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
+        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+        VERBATIM
       )
       add_custom_target(_copy_compile_commands
-          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
-          VERBATIM
+        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+        VERBATIM
       )
       message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
     else()
@@ -104,19 +104,20 @@ macro(common_project_options)
 
       # create an auxiliary target to help users switch confiurations
       add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
-          COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
-          VERBATIM
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
+        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+        VERBATIM
       )
       add_custom_target(_copy_compile_commands
-          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
-          VERBATIM
+        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+        VERBATIM
       )
       message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if switched among configurations.")
     endif()
 
     # Add compile_commans.json to .gitignore if .gitignore exists
     set(GITIGNORE_FILE "${CMAKE_SOURCE_DIR}/.gitignore")
+
     if(EXISTS ${GITIGNORE_FILE})
       file(STRINGS ${GITIGNORE_FILE} HAS_IGNORED REGEX "^compile_commands.json")
 

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -77,7 +77,11 @@ macro(common_project_options)
     # Make a symbol link of compile_commands.json on the source dir to help clang based tools find it
     if(WIN32)
       # Detect whether cmake is run as administrator (only administrator can read the LOCAL SERVICE account reg key)
-      cmake_host_system_information(RESULT QURY_RESULT QUERY WINDOWS_REGISTRY "HKU\\S-1-5-19" ERROR_VARIABLE IS_NONADMINISTRATOR)
+      execute_process(
+        COMMAND reg query "HKU\\S-1-5-19"
+        ERROR_VARIABLE IS_NONADMINISTRATOR
+        OUTPUT_QUIET
+      )
 
       if(IS_NONADMINISTRATOR)
         # For non-administrator, create an auxiliary target and ask user to run it

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -88,13 +88,13 @@ macro(common_project_options)
 
     if(IS_NONADMINISTRATOR)
       # For non-administrator, create an auxiliary target and ask user to run it
-      add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
+      add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
           COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
           VERBATIM
       )
       add_custom_target(_copy_compile_commands
-          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
           VERBATIM
       )
       message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
@@ -103,13 +103,13 @@ macro(common_project_options)
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
 
       # create an auxiliary target to help users switch confiurations
-      add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
+      add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
           COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
           VERBATIM
       )
       add_custom_target(_copy_compile_commands
-          DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+          DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
           VERBATIM
       )
       message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if switched among configurations.")

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -82,6 +82,8 @@ macro(common_project_options)
         ERROR_VARIABLE IS_NONADMINISTRATOR
         OUTPUT_QUIET
       )
+    else()
+      set(IS_NONADMINISTRATOR "")
     endif()
 
     if(IS_NONADMINISTRATOR)

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -82,37 +82,23 @@ macro(common_project_options)
         ERROR_VARIABLE IS_NONADMINISTRATOR
         OUTPUT_QUIET
       )
-    else()
-      set(IS_NONADMINISTRATOR "")
     endif()
 
     if(IS_NONADMINISTRATOR)
       # For non-administrator, create an auxiliary target and ask user to run it
-      add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
+      add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
         VERBATIM
       )
       add_custom_target(_copy_compile_commands
-        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
+        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
         VERBATIM
       )
       message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
     else()
-      # For others, symlink when cmake configures
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
-
-      # create an auxiliary target to help users switch confiurations
-      add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/compile_commands.json
-        COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
-        DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
-        VERBATIM
-      )
-      add_custom_target(_copy_compile_commands
-        DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
-        VERBATIM
-      )
-      message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if switched among configurations.")
+      message(STATUS "compile_commands.json was symlinked to the root.")
     endif()
 
     # Add compile_commans.json to .gitignore if .gitignore exists

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -97,6 +97,17 @@ macro(common_project_options)
     else()
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
     endif()
+
+    # Add `compile_commans.json` to `.gitignore` if `.gitignore` exists
+    set(GITIGNORE_FILE "${CMAKE_SOURCE_DIR}/.gitignore")
+    if(EXISTS ${GITIGNORE_FILE})
+      file(STRINGS ${GITIGNORE_FILE} HAS_IGNORED REGEX "^compile_commands.json")
+
+      if(NOT HAS_IGNORED)
+        message(STATUS "Adding `compile_commands.json` to `.gitignore`")
+        file(APPEND ${GITIGNORE_FILE} "\ncompile_commands.json")
+      endif()
+    endif()
   endif()
 
   # Enhance error reporting and compiler messages

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -69,8 +69,9 @@ macro(common_project_options)
         CACHE STRING "Fallbacks for the RelWithDebInfo build type")
   endif()
 
+  # Generate and possibly symlink compile_commands.json to make it easier to work with clang based tools
   if(CMAKE_GENERATOR MATCHES ".*Makefile*." OR CMAKE_GENERATOR MATCHES ".*Ninja*")
-    # Generate compile_commands.json to make it easier to work with clang based tools
+    # Enable generate compile_commands.json
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
     # Make a symbol link of compile_commands.json on the source dir to help clang based tools find it

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -93,11 +93,11 @@ macro(common_project_options)
         DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
         VERBATIM
       )
-      add_custom_target(_link_compile_commands
+      add_custom_target(_copy_compile_commands
         DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
         VERBATIM
       )
-      message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _link_compile_commands` if needed.")
+      message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
     else()
       # For others, symlink when cmake configures
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
@@ -108,11 +108,11 @@ macro(common_project_options)
         DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
         VERBATIM
       )
-      add_custom_target(_link_compile_commands
+      add_custom_target(_copy_compile_commands
         DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
         VERBATIM
       )
-      message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _link_compile_commands` if switched among configurations.")
+      message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if switched among configurations.")
     endif()
 
     # Add compile_commans.json to .gitignore if .gitignore exists

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -90,7 +90,7 @@ macro(common_project_options)
           DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
           VERBATIM
         )
-        message(STATUS "compile_commands was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
+        message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
       else()
         # For administrator, symlink is available
         file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -89,7 +89,7 @@ macro(common_project_options)
           DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
           VERBATIM
         )
-        message(AUTHOR_WARNING "Can't symlink compile_commands.json. Run cmake as administrator or use `cmake --build <build_dir> -t _copy_compile_commands` to copy it.")
+        message(STATUS "compile_commands was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
       else()
         # For administrator, symlink is available
         file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -69,8 +69,15 @@ macro(common_project_options)
         CACHE STRING "Fallbacks for the RelWithDebInfo build type")
   endif()
 
-  # Generate compile_commands.json to make it easier to work with clang based tools
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  if(CMAKE_GENERATOR MATCHES ".*Makefile*." OR CMAKE_GENERATOR MATCHES ".*Ninja*")
+    # Generate compile_commands.json to make it easier to work with clang based tools
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+    # Make a symbol link of compile_commands.json on the source dir to help clang based tools find it
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
+    )
+  endif()
 
   # Enhance error reporting and compiler messages
   if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")

--- a/src/Common.cmake
+++ b/src/Common.cmake
@@ -93,11 +93,11 @@ macro(common_project_options)
         DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
         VERBATIM
       )
-      add_custom_target(_copy_compile_commands
+      add_custom_target(_link_compile_commands
         DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
         VERBATIM
       )
-      message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if needed.")
+      message(STATUS "compile_commands.json was not symlinked to the root. Run `cmake --build <build_dir> -t _link_compile_commands` if needed.")
     else()
       # For others, symlink when cmake configures
       file(CREATE_LINK ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json SYMBOLIC)
@@ -108,11 +108,11 @@ macro(common_project_options)
         DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
         VERBATIM
       )
-      add_custom_target(_copy_compile_commands
+      add_custom_target(_link_compile_commands
         DEPENDS ${CMAKE_SOURCE_DIR}/compile_commands.json
         VERBATIM
       )
-      message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _copy_compile_commands` if switched among configurations.")
+      message(STATUS "compile_commands.json was symlinked to the root. Run `cmake --build <build_dir> -t _link_compile_commands` if switched among configurations.")
     endif()
 
     # Add compile_commans.json to .gitignore if .gitignore exists


### PR DESCRIPTION
It helps clang based tools to find `compile_commands.json` when using out-of-source builds, and to find the correct `compile_commands.json` when handling multiple builds.
Already tested in my [FeignClaims/cmake_starter_template](https://github.com/FeignClaims/cmake_starter_template/tree/main/cmake) (for the orign extension version, see `cmake/SymlinkCompileCommands.cmake`) when I switch between clang and gcc on MacOS and Windows.

Users should be notified to add `compile_commands.json` to `.gitignore` though.