### PR TITLE
Added riscv architecture to Utilities.cmake

### DIFF
--- a/src/Utilities.cmake
+++ b/src/Utilities.cmake
@@ -189,6 +189,14 @@ function(detect_architecture arch)
     set(${arch}
         arm64
         PARENT_SCOPE)
+  elseif(_arch STREQUAL riscv64)
+    set(${arch}
+        rv64
+        PARENT_SCOPE)
+  elseif(_arch STREQUAL riscv32)
+    set(${arch}
+        rv32
+        PARENT_SCOPE)
   else()
     # fallback to the most common architecture
     message(STATUS "Unknown architecture ${_arch} - using x64")


### PR DESCRIPTION
Added statements to detect when system processor is either riscv64 or riscv32  and put rv64 or rv32 respectively,  into the arch variable. This keeps these cases from falling through and accidentally picking up the x64 arch flags.