### PR TITLE
fix: packaging for `target_include_interface_directories`

### DIFF
--- a/src/PackageProject.cmake
+++ b/src/PackageProject.cmake
@@ -123,7 +123,7 @@ function(package_project)
       OUTPUT
       "PROPERTY_${property}")
   endmacro()
-  _get_property(INTERFACE_INCLUDES)
+  _get_property(INTERFACE_DIRECTORIES)
   _get_property(INTERFACE_DEPENDENCIES)
   _get_property(PUBLIC_DEPENDENCIES)
   _get_property(PRIVATE_DEPENDENCIES)


### PR DESCRIPTION
A heavy mistake: I confidently forgot to re-test after renaming for consistency. As a result, there's one name left unchanged.

Now tested. Hopefully no more silly bugs.