### PR TITLE
fix: Disable `-fstack-clash-protection` on MacOS M1 when using Clang

### DIFF
--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -19,7 +19,20 @@ function(
     endif()
 
     if(${ENABLE_STACK_PROTECTION})
-      list(APPEND HARDENING_COMPILE_OPTIONS -fstack-protector-strong -fstack-clash-protection)
+      set(_enable_stack_clash_protection TRUE)
+      if (APPLE)
+        EXECUTE_PROCESS(COMMAND uname -m OUTPUT_VARIABLE _architecture)
+        # `-fstack-clash-protection` dosen't work on MacOS M1 with clang
+        if (${_architecture} STREQUAL "arm64" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+          set(_enable_stack_clash_protection FALSE)
+        endif()
+      endif()
+
+      if (_enable_stack_clash_protection)
+        list(APPEND HARDENING_COMPILE_OPTIONS -fstack-clash-protection)
+      endif()
+
+      list(APPEND HARDENING_COMPILE_OPTIONS -fstack-protector-strong)
     endif()
 
     if(${ENABLE_OVERFLOW_PROTECTION})

--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -23,7 +23,7 @@ function(
       if (APPLE)
         EXECUTE_PROCESS(COMMAND uname -m OUTPUT_VARIABLE _architecture)
         # `-fstack-clash-protection` dosen't work on MacOS M1 with clang
-        if (${_architecture} STREQUAL "arm64" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        if (_architecture MATCHES ".*arm64.*" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
           set(_enable_stack_clash_protection FALSE)
         endif()
       endif()

--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -21,9 +21,8 @@ function(
     if(${ENABLE_STACK_PROTECTION})
       set(_enable_stack_clash_protection TRUE)
       if (APPLE)
-        EXECUTE_PROCESS(COMMAND uname -m OUTPUT_VARIABLE _architecture)
         # `-fstack-clash-protection` dosen't work on MacOS M1 with clang
-        if (_architecture MATCHES ".*arm64.*" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
           set(_enable_stack_clash_protection FALSE)
         endif()
       endif()


### PR DESCRIPTION
Currently when using Clang on MacOS M1, enabling both `ENABLE_STACK_PROTECTION` and `WARNINGS_AS_ERRORS` prevents compilation:

```bash
clang-16: error: argument unused during compilation: '-fstack-clash-protection' [-Werror,-Wunused-command-line-argument]
```

That is, the `-fstack-clash-protection` part (currently) isn't supported on this environment. Since the `-fstack-protector-strong` part in `ENABLE_STACK_PROTECTION` works, I propose to fix the option instead of requiring users to disable it.