### PR TITLE
fix: force cloning if the directory exists in `git_clone` function

### DIFF
--- a/src/Git.cmake
+++ b/src/Git.cmake
@@ -12,10 +12,11 @@ Input variables:
 - ``REPOSITORY_PATH``: The path to the repository
 - ``REMOTE_URL``: The url of the remote to add
 - ``REMOTE_NAME``: The name of the remote to add (defaults to the remote user)
+- ``FORCE_CLONE``: Force the clone even if the directory exists
 
 ]]
 function(git_clone)
-  set(oneValueArgs REPOSITORY_PATH REMOTE_URL REMOTE_NAME FORCE)
+  set(oneValueArgs REPOSITORY_PATH REMOTE_URL REMOTE_NAME FORCE_CLONE)
   cmake_parse_arguments(_fun "" "${oneValueArgs}" "" ${ARGN})
 
   if("${_fun_REPOSITORY_PATH}" STREQUAL "" OR "${_fun_REMOTE_URL}" STREQUAL "")
@@ -23,7 +24,7 @@ function(git_clone)
   endif()
 
   # the folder is created as soon as the clone starts
-  if(NOT EXISTS "${_fun_REPOSITORY_PATH}" OR "${_fun_FORCE}" STREQUAL "TRUE")
+  if(NOT EXISTS "${_fun_REPOSITORY_PATH}" OR "${_fun_FORCE_CLONE}" STREQUAL "TRUE")
     message(STATUS "Cloning at ${_fun_REPOSITORY_PATH}")
 
     find_program(GIT_EXECUTABLE "git" REQUIRED)
@@ -51,7 +52,7 @@ function(git_clone)
         "${_fun_REMOTE_URL}"
         REMOTE_NAME
         "${_fun_REMOTE_NAME}"
-        FORCE
+        FORCE_CLONE
         TRUE
       )
     endif()

--- a/src/Git.cmake
+++ b/src/Git.cmake
@@ -362,12 +362,29 @@ function(git_switch_back)
   endif()
 endfunction()
 
+#[[.rst:
+
+``git_wait``
+============
+
+Wait for the git lock file to be released
+
+Input variables:
+
+- ``REPOSITORY_PATH``: The path to the repository
+- ``TIMEOUT_COUNTER``: The number of times to wait before timing out
+
+]]
 function(git_wait)
-  set(oneValueArgs REPOSITORY_PATH)
+  set(oneValueArgs REPOSITORY_PATH TIMEOUT_COUNTER)
   cmake_parse_arguments(_fun "" "${oneValueArgs}" "" ${ARGN})
 
   if("${_fun_REPOSITORY_PATH}" STREQUAL "")
     message(FATAL_ERROR "REPOSITORY_PATH is required")
+  endif()
+
+  if("${_fun_TIMEOUT_COUNTER}" STREQUAL "")
+    set(_fun_TIMEOUT_COUNTER 20)
   endif()
 
   set(counter 0)
@@ -379,9 +396,11 @@ function(git_wait)
     execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 0.5)
 
     math(EXPR counter "${counter} + 1")
-    if(${counter} GREATER 20)
+    if(${counter} GREATER ${_fun_TIMEOUT_COUNTER})
       message(STATUS "Timeout waiting for git lock file. Continuing...")
       return()
+    else()
+      message(STATUS "Waiting for git lock file...[${counter}/${_fun_TIMEOUT_COUNTER}]")
     endif()
   endwhile()
 endfunction()


### PR DESCRIPTION
In some cases, the directory might exist but not be there because of another git process cloning. This timeout allows cloning in that directory. Git will error out with more information if it fails.