### PR TITLE
feat: support conan 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,11 @@ jobs:
           cmake: ${{ matrix.cmake }}
           ninja: true
           vcpkg: true
-          conan: false
+          conan: 2.1.0
           cppcheck: true
           clangtidy: true
           task: true
           doxygen: ${{ !contains(matrix.os, 'macos-11') }}
-
-      - name: Install conan2
-        run: |
-          pip3 install conan==2.1.0
 
       - name: Test
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,15 @@ jobs:
           cmake: ${{ matrix.cmake }}
           ninja: true
           vcpkg: true
-          conan: true
+          conan: false
           cppcheck: true
           clangtidy: true
           task: true
           doxygen: ${{ !contains(matrix.os, 'macos-11') }}
+
+      - name: Install conan2
+        run: |
+          pip3 install conan==2.1.0
 
       - name: Test
         if: ${{ !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ CMake experience following the best practices.
     FetchContent, vcpkg, etc.
 -   `run_vcpkg`: automatic installation of vcpkg and the project
     dependencies
+-   `run_conan2`: automatic installation of vcpkg and the project
+    dependencies
 -   `ENABLE_CONAN` in `project_options`: automatic installation of Conan
     and the project dependencies
 -   `dynamic_project_options`: a wrapper around `project_options` to

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ run_vcpkg(
     VCPKG_URL "https://github.com/microsoft/vcpkg.git"
     VCPKG_REV "10e052511428d6b0c7fcc63a139e8024bb146032"
 )
+# Install conan dependencies: - should be called before defining project()
+run_conan()
 
 # Set the project name and language
 project(myproject LANGUAGES CXX C)

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ CMake experience following the best practices.
     FetchContent, vcpkg, etc.
 -   `run_vcpkg`: automatic installation of vcpkg and the project
     dependencies
--   `run_conan2`: automatic installation of vcpkg and the project
+-   `run_conan`: automatic installation of conan and the project
     dependencies
--   `ENABLE_CONAN` in `project_options`: automatic installation of Conan
-    and the project dependencies
 -   `dynamic_project_options`: a wrapper around `project_options` to
     change the options on the fly dynamically
 -   `target_link_system_libraries` and
@@ -121,7 +119,6 @@ project_options(
       ${ENABLE_CPPCHECK}
       ${ENABLE_CLANG_TIDY}
       ENABLE_VS_ANALYSIS
-      # ENABLE_CONAN
       # ENABLE_INTERPROCEDURAL_OPTIMIZATION
       # ENABLE_NATIVE_OPTIMIZATION
       ${ENABLE_DOXYGEN}
@@ -144,7 +141,6 @@ project_options(
       # ENABLE_BUILD_WITH_TIME_TRACE
       # ENABLE_UNITY
       # LINKER "lld"
-      # CONAN_PROFILE ${profile_path}
 )
 ```
 

--- a/docs/src/Readme_top.md
+++ b/docs/src/Readme_top.md
@@ -22,6 +22,7 @@ A general-purpose CMake library that provides functions that improve the CMake e
   - using custom linkers (e.g. lld)
 - `package_project`: automatic packaging/installation of the project for seamless usage via find_package/target_link through CMake's FetchContent, vcpkg, etc.
 - `run_vcpkg`: automatic installation of vcpkg and the project dependencies
+- `run_conan2`: automatic installation of Conan 2 and the project dependencies
 - `ENABLE_CONAN` in `project_options`: automatic installation of Conan and the project dependencies
 - `dynamic_project_options`: a wrapper around `project_options` to change the options on the fly dynamically
 - `target_link_system_libraries` and `target_include_system_directories`: linking/including external dependencies/headers without warnings

--- a/docs/src/Readme_top.md
+++ b/docs/src/Readme_top.md
@@ -22,8 +22,7 @@ A general-purpose CMake library that provides functions that improve the CMake e
   - using custom linkers (e.g. lld)
 - `package_project`: automatic packaging/installation of the project for seamless usage via find_package/target_link through CMake's FetchContent, vcpkg, etc.
 - `run_vcpkg`: automatic installation of vcpkg and the project dependencies
-- `run_conan2`: automatic installation of Conan 2 and the project dependencies
-- `ENABLE_CONAN` in `project_options`: automatic installation of Conan and the project dependencies
+- `run_conan`: automatic installation of conan and the project dependencies
 - `dynamic_project_options`: a wrapper around `project_options` to change the options on the fly dynamically
 - `target_link_system_libraries` and `target_include_system_directories`: linking/including external dependencies/headers without warnings
 - `target_link_cuda`: linking Cuda to a target

--- a/docs/src/project_options_example.md
+++ b/docs/src/project_options_example.md
@@ -73,7 +73,6 @@ project_options(
       ${ENABLE_CPPCHECK}
       ${ENABLE_CLANG_TIDY}
       ENABLE_VS_ANALYSIS
-      # ENABLE_CONAN
       # ENABLE_INTERPROCEDURAL_OPTIMIZATION
       # ENABLE_NATIVE_OPTIMIZATION
       ${ENABLE_DOXYGEN}
@@ -96,7 +95,6 @@ project_options(
       # ENABLE_BUILD_WITH_TIME_TRACE
       # ENABLE_UNITY
       # LINKER "lld"
-      # CONAN_PROFILE ${profile_path}
 )
 ```
 

--- a/docs/src/project_options_example.md
+++ b/docs/src/project_options_example.md
@@ -33,6 +33,8 @@ run_vcpkg(
     VCPKG_REV "10e052511428d6b0c7fcc63a139e8024bb146032"
     ENABLE_VCPKG_UPDATE
 )
+# Install conan dependencies: - should be called before defining project()
+run_conan()
 
 # Set the project name and language
 project(myproject LANGUAGES CXX C)

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -247,5 +247,5 @@ macro(run_conan2)
 
   # Add this to invoke conan even when there's no find_package in CMakeLists.txt.
   # This helps users get the third-party package names, which is used in later find_package.
-  cmake_language(DEFER DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} CALL find_package Git)
+  cmake_language(DEFER DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} CALL find_package Git QUIET)
 endmacro()

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -37,7 +37,7 @@ macro(_run_conan1)
   if(_conan_current_version VERSION_GREATER_EQUAL "2.0.0")
     message(FATAL_ERROR
       "ENABLE_CONAN in project_options(...) only supports conan 1.\n"
-      "  If you're using conan 2, disable ENABLE_CONAN and use run_conan2(...) before project(...).")
+      "  If you're using conan 2, disable ENABLE_CONAN and use run_conan(...) before project(...).")
   endif()
 
   # Download automatically, you can also just copy the conan.cmake file
@@ -193,15 +193,15 @@ macro(_run_conan2)
 
   if(CMAKE_VERSION VERSION_LESS "3.24.0")
     message(FATAL_ERROR
-      "run_conan2 only supports cmake 3.24+, please update your cmake.\n"
-      "  If you're using conan 1, set ENABLE_CONAN using project_options(...) or dynamic_project_options(...) after project().")
+      "`run_conan(...)` with conan 2 only supports cmake 3.24+, please update your cmake.\n"
+      "  Or you can downgrade your conan to use conan 1.")
   endif()
 
   conan_get_version(_conan_current_version)
   if(_conan_current_version VERSION_LESS "2.0.5")
     message(FATAL_ERROR
-      "run_conan2 only supports conan 2.0.5+, please update your conan.\n"
-      "  If you're using conan 1, set ENABLE_CONAN using project_options(...) or dynamic_project_options(...) after project().")
+      "run_conan(...) with conan 2 only supports conan 2.0.5+, please update your conan.\n"
+      "  Or You can downgrade your conan to use conan 1.")
   endif()
 
   # Download automatically, you can also just copy the conan.cmake file

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -244,4 +244,8 @@ macro(run_conan2)
 
   # A workaround from https://github.com/conan-io/cmake-conan/issues/595
   list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES ${CMAKE_BINARY_DIR}/conan_provider.cmake)
+
+  # Add this to invoke conan even when there's no find_package in CMakeLists.txt.
+  # This helps users get the third-party package names, which is used in later find_package.
+  cmake_language(DEFER DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} CALL find_package Git)
 endmacro()

--- a/src/Conan.cmake
+++ b/src/Conan.cmake
@@ -36,8 +36,8 @@ macro(_run_conan1)
   conan_get_version(_conan_current_version)
   if(_conan_current_version VERSION_GREATER_EQUAL "2.0.0")
     message(FATAL_ERROR
-      "ENABLE_CONAN in project_options(...) only supports conan 1.\n"
-      "  If you're using conan 2, disable ENABLE_CONAN and use run_conan(...) before project(...).")
+      "ENABLE_CONAN in `project_options(...)` only supports conan 1.\n"
+      "  If you're using conan 2, disable ENABLE_CONAN and use `run_conan(...)` before `project(...)`.")
   endif()
 
   # Download automatically, you can also just copy the conan.cmake file
@@ -200,7 +200,7 @@ macro(_run_conan2)
   conan_get_version(_conan_current_version)
   if(_conan_current_version VERSION_LESS "2.0.5")
     message(FATAL_ERROR
-      "run_conan(...) with conan 2 only supports conan 2.0.5+, please update your conan.\n"
+      "`run_conan(...)` with conan 2 only supports conan 2.0.5+, please update your conan.\n"
       "  Or You can downgrade your conan to use conan 1.")
   endif()
 

--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -64,15 +64,14 @@ Here is an example of how to use ``dynamic_project_options``:
 
    # install vcpkg dependencies: - should be called before defining project()
    # run_vcpkg()
+   # install conan dependencies: - should be called before defining project()
+   # run_conan()
 
    # Set the project name and language
    project(myproject LANGUAGES CXX C)
 
    # Set PCH to be on by default for all non-Developer Mode Builds
    set(ENABLE_PCH_USER_DEFAULT ON)
-
-   # enable Conan
-   set(ENABLE_CONAN_DEFAULT ON)
 
    # Initialize project_options variable related to this project
    # This overwrites `project_options` and sets `project_warnings`

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -113,8 +113,6 @@ front of them:
    cppcheck
 -  ``VS_ANALYSIS_RULESET``: Override the defaults for the code analysis
    rule set in Visual Studio.
--  ``CONAN_OPTIONS``: Extra Conan options
--  ``CONAN_PROFILE``: Passes a profile to conan: see https://docs.conan.io/en/latest/reference/profiles.html
 
 
 ]]

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -59,7 +59,6 @@ include("${ProjectOptions_SRC_DIR}/Vcpkg.cmake")
 -  ``ENABLE_CLANG_TIDY``: Enable static analysis with clang-tidy
 -  ``ENABLE_VS_ANALYSIS``: Enable Visual Studio IDE code analysis if the
    generator is Visual Studio.
--  ``ENABLE_CONAN``: Use Conan for dependency management
 -  ``ENABLE_INTERPROCEDURAL_OPTIMIZATION``: Enable Interprocedural
    Optimization (Link Time Optimization, LTO) in the release build
 -  ``ENABLE_NATIVE_OPTIMIZATION``: Enable the optimizations specific to
@@ -308,7 +307,19 @@ macro(project_options)
   endif()
 
   if(${ProjectOptions_ENABLE_CONAN})
-    run_conan()
+    _run_conan1(
+      DEPRECATED_CALL
+      DEPRECATED_PROFILE ${ProjectOptions_CONAN_PROFILE}
+      HOST_PROFILE ${ProjectOptions_CONAN_HOST_PROFILE}
+      BUILD_PROFILE ${ProjectOptions_CONAN_BUILD_PROFILE}
+      DEPRECATED_OPTIONS ${ProjectOptions_CONAN_OPTIONS}
+    )
+  endif()
+
+  get_property(_should_invoke_conan1 DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" PROPERTY PROJECT_OPTIONS_SHOULD_INVOKE_CONAN1)
+  if(_should_invoke_conan1)
+    get_property(conan1_args DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" PROPERTY PROJECT_OPTIONS_CONAN1_ARGS)
+    _run_conan1(${conan1_args})
   endif()
 
   if(${ProjectOptions_ENABLE_UNITY})

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16...3.21)
 include(../../src/Index.cmake)
 
 run_vcpkg()
-run_conan2()
+run_conan()
 
 project(anotherproj VERSION 0.1.0 LANGUAGES CXX C)
 

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -4,13 +4,13 @@ cmake_minimum_required(VERSION 3.16...3.21)
 include(../../src/Index.cmake)
 
 run_vcpkg()
+run_conan2()
 
 project(anotherproj VERSION 0.1.0 LANGUAGES CXX C)
 
 # Initialize project_options
 project_options(
   ENABLE_CACHE
-  ENABLE_CONAN
   # WARNINGS_AS_ERRORS
   ENABLE_CPPCHECK
   ENABLE_CLANG_TIDY

--- a/tests/install/conanfile.txt
+++ b/tests/install/conanfile.txt
@@ -4,4 +4,4 @@
 docopt.cpp/0.6.3
 
 [generators]
-cmake_find_package_multi
+CMakeDeps

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 run_vcpkg(VCPKG_URL "https://github.com/microsoft/vcpkg.git" VCPKG_REV
           "10e052511428d6b0c7fcc63a139e8024bb146032" ENABLE_VCPKG_UPDATE
 )
-run_conan2()
+run_conan()
 
 project(myproj VERSION 0.2.0 LANGUAGES CXX C)
 

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 run_vcpkg(VCPKG_URL "https://github.com/microsoft/vcpkg.git" VCPKG_REV
           "10e052511428d6b0c7fcc63a139e8024bb146032" ENABLE_VCPKG_UPDATE
 )
+run_conan2()
 
 project(myproj VERSION 0.2.0 LANGUAGES CXX C)
 
@@ -54,7 +55,6 @@ project_options(
   PREFIX
   "myproj"
   ENABLE_CACHE
-  ENABLE_CONAN
   # WARNINGS_AS_ERRORS
   ENABLE_CPPCHECK
   ENABLE_CLANG_TIDY

--- a/tests/myproj/conanfile.txt
+++ b/tests/myproj/conanfile.txt
@@ -4,4 +4,4 @@
 docopt.cpp/0.6.3
 
 [generators]
-cmake_find_package_multi
+CMakeDeps


### PR DESCRIPTION
Support conan 2 by replacing the old conan script with [`conan_provider.cmake`](https://github.com/conan-io/cmake-conan/blob/develop2/conan_provider.cmake).

Todo:

- [ ] customizing conan profiles and invocation of conan install.

Current design questions:

- The new `conan_provider.cmake` script for conan 2 requires CMake 2.24+. Is it acceptable to set `cmake_minimum_required(VERSION 3.24)` for the whole project_options?
- The cmake script for conan 2 is incompatible with conan 1. Should I keep the conan 1 function or replace it?

Close #212 