### PR TITLE
fix: support iterating list containing generator expressions that have semicolons

### DIFF
--- a/src/PackageProject.cmake
+++ b/src/PackageProject.cmake
@@ -1,5 +1,7 @@
 include_guard()
 
+include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
+
 # Uses ycm (permissive BSD-3-Clause license) and ForwardArguments (permissive MIT license)
 
 function(get_property_of_targets)
@@ -15,7 +17,8 @@ function(get_property_of_targets)
       list(APPEND _Value ${_Current_property})
     endif()
   endforeach()
-  list(REMOVE_DUPLICATES _Current_property)
+  convert_genex_semicolons("${_Value}" _Value)
+  list(REMOVE_DUPLICATES _Value)
   set(${args_OUTPUT} ${_Value} PARENT_SCOPE)
 endfunction()
 

--- a/src/SystemLink.cmake
+++ b/src/SystemLink.cmake
@@ -1,5 +1,7 @@
 include_guard()
 
+include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
+
 #[[.rst:
 
 ``target_include_system_directories``
@@ -18,6 +20,7 @@ function(target_include_system_directories target)
   cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
 
   foreach(scope IN ITEMS INTERFACE PUBLIC PRIVATE)
+    convert_genex_semicolons("${ARG_${scope}}" "ARG_${scope}")
     foreach(lib_include_dirs IN LISTS ARG_${scope})
       if(NOT MSVC OR (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0"
                       AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "19.29.30036.3")
@@ -83,6 +86,7 @@ function(target_link_system_libraries target)
   cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
 
   foreach(scope IN ITEMS INTERFACE PUBLIC PRIVATE)
+    convert_genex_semicolons("${ARG_${scope}}" "ARG_${scope}")
     foreach(lib IN LISTS ARG_${scope})
       target_link_system_library(${target} ${scope} ${lib})
     endforeach()

--- a/src/Utilities.cmake
+++ b/src/Utilities.cmake
@@ -124,3 +124,52 @@ function(detect_architecture arch)
     set(${arch} x64 PARENT_SCOPE)
   endif()
 endfunction()
+
+# convert semicolons in generator expression to $<SEMICOLON>
+function(convert_genex_semicolons genex output)
+  set(result)
+
+  set(depth 0)
+  set(index 0)
+  set(prefixed_with_dollar FALSE)
+  string(LENGTH "${genex}" length)
+
+  while(index LESS length)
+    string(SUBSTRING "${genex}" ${index} 1 ch)
+
+    if(ch STREQUAL "$")
+      set(prefixed_with_dollar TRUE)
+      string(APPEND result "${ch}")
+    elseif(ch STREQUAL "<")
+      if(prefixed_with_dollar)
+        set(prefixed_with_dollar FALSE)
+        math(EXPR depth "${depth}+1")
+      endif()
+
+      string(APPEND result "${ch}")
+    elseif(ch STREQUAL ">")
+      set(prefixed_with_dollar FALSE)
+
+      if(depth GREATER 0)
+        math(EXPR depth "${depth}-1")
+      endif()
+
+      string(APPEND result "${ch}")
+    elseif(ch STREQUAL ";")
+      set(prefixed_with_dollar FALSE)
+
+      if(depth GREATER 0)
+        string(APPEND result "$<SEMICOLON>")
+      else()
+        string(APPEND result "${ch}")
+      endif()
+    else()
+      set(prefixed_with_dollar FALSE)
+      string(APPEND result "${ch}")
+    endif()
+
+    math(EXPR index "${index}+1")
+  endwhile()
+
+  set("${output}" "${result}" PARENT_SCOPE)
+endfunction()

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -102,9 +102,9 @@ add_test(NAME main COMMAND main)
 # Header-only library
 add_library(lib INTERFACE)
 set(lib_INCLUDE_DIR "include")
-target_include_directories(
-  lib INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${lib_INCLUDE_DIR}>"
-                "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_system_directories( # Test the fix of semicolon in genex issue
+  lib INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}/${lib_INCLUDE_DIR}>"
+  "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>"
 ) # TODO(refactor)
 target_link_libraries(lib INTERFACE myproj_project_options myproj_project_warnings)
 target_link_system_libraries(lib INTERFACE fmt::fmt Eigen3::Eigen)


### PR DESCRIPTION
Add a function `convert_genex_semicolons` to convert semicolons inside generator expressions into `$<SEMICOLON>`. After this function, the list contains generator expressions can be properly iterated.

```cmake
set(dirs "$<$<CONFIG:Debug>:dir1;dir2>" "$<$<CONFIG:Release>:dir3;dir4>")

convert_genex_semicolons("${dirs}" dirs)
# now dirs is "$<$<CONFIG:Debug>:dir1$<SEMICOLON>dir2>;$<$<CONFIG:Release>:dir3$<SEMICOLON>dir4>"

foreach(dir IN LISTS dirs)
  # element 0: "$<$<CONFIG:Debug>:dir1$<SEMICOLON>dir2>"
  # element 1: "$<$<CONFIG:Release>:dir3$<SEMICOLON>dir4>"
endforeach()
```

Close #205 