### PR TITLE
fix: Disable gcc sanitizer on macos by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
             compiler: "gcc"
             cmake: true
             vcvarsall: true
+          - os: "macos-13"
+            compiler: "gcc"
+            cmake: true
+            vcvarsall: true
         exclude:
           # fails with an internal error
           - os: "macos-12"
@@ -80,7 +84,7 @@ jobs:
           cppcheck: true
           clangtidy: true
           task: true
-          doxygen: ${{ !contains(matrix.os, 'macos-11') }}
+          doxygen: ${{ !contains(matrix.os, 'macos-11') && !contains(matrix.os, 'macos-13') }}
 
       - name: Test
         if: ${{ !cancelled() }}

--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -1,5 +1,7 @@
 include_guard()
 
+include("${CMAKE_CURRENT_LIST_DIR}/Sanitizers.cmake")
+
 #[[.rst:
 
 ``dynamic_project_options``
@@ -101,14 +103,24 @@ macro(dynamic_project_options)
     )
   endif()
 
-  if(((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*") AND (NOT WIN32))
-    OR ((CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*") AND (NOT WIN32) AND (NOT APPLE))
+  check_sanitizers_support(
+    ENABLE_SANITIZER_ADDRESS
+    ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
+    ENABLE_SANITIZER_LEAK
+    ENABLE_SANITIZER_THREAD
+    ENABLE_SANITIZER_MEMORY
   )
-    set(SUPPORTS_UBSAN ON)
+
+  if(ENABLE_SANITIZER_ADDRESS)
     set(SUPPORTS_ASAN ON)
   else()
-    set(SUPPORTS_UBSAN OFF)
     set(SUPPORTS_ASAN OFF)
+  endif()
+
+  if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
+    set(SUPPORTS_UBSAN ON)
+  else()
+    set(SUPPORTS_UBSAN OFF)
   endif()
 
   # ccache, clang-tidy, cppcheck are only supported with Ninja and Makefile based generators

--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -101,20 +101,14 @@ macro(dynamic_project_options)
     )
   endif()
 
-  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*")
-     AND NOT WIN32
+  if(((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*") AND (NOT WIN32))
+    OR ((CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*") AND (NOT WIN32) AND (NOT APPLE))
   )
     set(SUPPORTS_UBSAN ON)
+    set(SUPPORTS_ASAN ON)
   else()
     set(SUPPORTS_UBSAN OFF)
-  endif()
-
-  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*")
-     AND WIN32
-  )
     set(SUPPORTS_ASAN OFF)
-  else()
-    set(SUPPORTS_ASAN ON)
   endif()
 
   # ccache, clang-tidy, cppcheck are only supported with Ninja and Makefile based generators

--- a/src/Utilities.cmake
+++ b/src/Utilities.cmake
@@ -125,6 +125,15 @@ function(detect_architecture arch)
   endif()
 endfunction()
 
+function(detect_macos_version version)
+  find_program(SW_VERS_EXECUTABLE sw_vers)
+  execute_process(
+    COMMAND "${SW_VERS_EXECUTABLE}" -productVersion
+    OUTPUT_VARIABLE MACOS_VERSION
+  )
+  set(${version} "${MACOS_VERSION}" PARENT_SCOPE)
+endfunction()
+
 # convert semicolons in generator expression to $<SEMICOLON>
 function(convert_genex_semicolons genex output)
   set(result)

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -8,7 +8,7 @@ run_conan()
 
 project(anotherproj VERSION 0.1.0 LANGUAGES CXX C)
 
-option(FEATURE_TESTS "Enable the tests" OFF)
+option(FEATURE_TESTS "Enable the tests" ON)
 if(FEATURE_TESTS)
   # Enable sanitizers and static analyzers when running the tests
   check_sanitizers_support(

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -8,6 +8,26 @@ run_conan()
 
 project(anotherproj VERSION 0.1.0 LANGUAGES CXX C)
 
+option(FEATURE_TESTS "Enable the tests" OFF)
+if(FEATURE_TESTS)
+  # Enable sanitizers and static analyzers when running the tests
+  check_sanitizers_support(
+    ENABLE_SANITIZER_ADDRESS ENABLE_SANITIZER_UNDEFINED_BEHAVIOR ENABLE_SANITIZER_LEAK
+    ENABLE_SANITIZER_THREAD ENABLE_SANITIZER_MEMORY
+  )
+endif()
+
+set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "ENABLE_INTERPROCEDURAL_OPTIMIZATION")
+if(APPLE)
+  detect_macos_version(apple_version)
+  if(apple_version VERSION_GREATER_EQUAL 13)
+    # workaround for linkage error as described in https://github.com/Homebrew/homebrew-core/issues/145991
+    # although fixed, this problem still exists in github actions
+    add_link_options(-Wl,-ld_classic)
+    set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "")
+  endif()
+endif()
+
 # Initialize project_options
 project_options(
   ENABLE_CACHE
@@ -23,14 +43,14 @@ project_options(
   DOXYGEN_THEME
   "${CMAKE_CURRENT_LIST_DIR}/css/my_custom_theme.css"
   "${CMAKE_CURRENT_LIST_DIR}/css/my_custom_theme_extra.css"
-  ENABLE_INTERPROCEDURAL_OPTIMIZATION
+  ${ENABLE_INTERPROCEDURAL_OPTIMIZATION}
   # ENABLE_BUILD_WITH_TIME_TRACE
   # ENABLE_UNITY
-  # ENABLE_SANITIZER_ADDRESS
-  # ENABLE_SANITIZER_LEAK
-  # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
-  # ENABLE_SANITIZER_THREAD
-  # ENABLE_SANITIZER_MEMORY
+  ${ENABLE_SANITIZER_ADDRESS}
+  # ${ENABLE_SANITIZER_LEAK}
+  ${ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}
+  # ${ENABLE_SANITIZER_THREAD}
+  # ${ENABLE_SANITIZER_MEMORY}
 )
 
 # add src, tests, etc here:

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -33,7 +33,7 @@ set(PCH_HEADERS
     <string_view>
 )
 
-option(FEATURE_TESTS "Enable the tests" OFF)
+option(FEATURE_TESTS "Enable the tests" ON)
 
 if(FEATURE_TESTS)
   # Enable sanitizers and static analyzers when running the tests
@@ -42,9 +42,6 @@ if(FEATURE_TESTS)
     ENABLE_SANITIZER_THREAD ENABLE_SANITIZER_MEMORY
   )
 endif()
-
-include(CMakePrintHelpers)
-cmake_print_variables(ENABLE_SANITIZER_ADDRESS ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
 
 # Detect custom linker
 if(NOT MSVC)

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -49,6 +49,17 @@ if(NOT MSVC)
   #message(STATUS "Detect Linker: ${LINKER}")
 endif()
 
+set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "ENABLE_INTERPROCEDURAL_OPTIMIZATION")
+if(APPLE)
+  detect_macos_version(apple_version)
+  if(apple_version VERSION_GREATER_EQUAL 13)
+    # workaround for linkage error as described in https://github.com/Homebrew/homebrew-core/issues/145991
+    # although fixed, this problem still exists in github actions
+    add_link_options(-Wl,-ld_classic)
+    set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "")
+  endif()
+endif()
+
 # Initialize project_options
 # uncomment the options to enable them
 project_options(
@@ -65,7 +76,7 @@ project_options(
   # PCH_HEADERS
   # ${PCH_HEADERS}
   ENABLE_DOXYGEN
-  ENABLE_INTERPROCEDURAL_OPTIMIZATION
+  ${ENABLE_INTERPROCEDURAL_OPTIMIZATION}
   ENABLE_NATIVE_OPTIMIZATION
   # ENABLE_BUILD_WITH_TIME_TRACE
   # ENABLE_UNITY

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -43,6 +43,9 @@ if(FEATURE_TESTS)
   )
 endif()
 
+include(CMakePrintHelpers)
+cmake_print_variables(ENABLE_SANITIZER_ADDRESS ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
+
 # Detect custom linker
 if(NOT MSVC)
   find_linker(LINKER)

--- a/tests/myproj/Taskfile.yml
+++ b/tests/myproj/Taskfile.yml
@@ -24,13 +24,13 @@ tasks:
     cmds:
       - task: build
         vars:
-          CMAKE_ARGS: -DFEATURE_TESTS:BOOL=ON -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
+          CMAKE_ARGS: -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
 
   build.mingw.release:
     cmds:
       - task: build.release
         vars:
-          CMAKE_ARGS: -DFEATURE_TESTS:BOOL=ON -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
+          CMAKE_ARGS: -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
 
   lint:
     - ~/vcpkg/vcpkg format-manifest ./vcpkg.json

--- a/tests/myproj/Taskfile.yml
+++ b/tests/myproj/Taskfile.yml
@@ -24,13 +24,13 @@ tasks:
     cmds:
       - task: build
         vars:
-          CMAKE_ARGS: -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
+          CMAKE_ARGS: -DFEATURE_TESTS:BOOL=ON -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
 
   build.mingw.release:
     cmds:
       - task: build.release
         vars:
-          CMAKE_ARGS: -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
+          CMAKE_ARGS: -DFEATURE_TESTS:BOOL=ON -DENABLE_CROSS_COMPILING:BOOL=ON -DCMAKE_C_COMPILER={{.CROSS_CC | default "x86_64-w64-mingw32-gcc"}} -DCMAKE_CXX_COMPILER={{.CROSS_CXX | default "x86_64-w64-mingw32-g++"}}
 
   lint:
     - ~/vcpkg/vcpkg format-manifest ./vcpkg.json


### PR DESCRIPTION
According to [this comment](https://github.com/orgs/Homebrew/discussions/3384#discussioncomment-6264292), gcc now dosen't support libsanitizer on macOS with arm64 and macOS Ventuna or later with x86_64.