### PR TITLE
feat: `target_find_dependencies` with `find_package` args

### DIFF
--- a/src/PackageProject.cmake
+++ b/src/PackageProject.cmake
@@ -319,19 +319,6 @@ function(package_project)
   include("${_ycm_SOURCE_DIR}/modules/AddUninstallTarget.cmake")
 endfunction()
 
-function(set_or_append_target_property target property new_values)
-  get_target_property(_AllValues ${target} ${property})
-
-  if(NOT _AllValues) # If the property hasn't set
-    set(_AllValues "${new_values}")
-  else()
-    list(APPEND _AllValues ${new_values})
-  endif()
-  list(REMOVE_DUPLICATES _AllValues)
-
-  set_target_properties(${target} PROPERTIES ${property} "${_AllValues}")
-endfunction()
-
 #[[.rst:
 
 ``target_include_interface_directories``
@@ -378,7 +365,7 @@ function(target_include_interface_directories target)
     endif()
 
     # Append include_dir to target property PROJECT_OPTIONS_INTERFACE_DIRECTORIES
-    set_or_append_target_property(${target} "PROJECT_OPTIONS_INTERFACE_DIRECTORIES" ${include_dir})
+    set_property(TARGET ${target} APPEND PROPERTY "PROJECT_OPTIONS_INTERFACE_DIRECTORIES" ${include_dir})
 
     # Include the interface directory
     get_target_property(_HasSourceFiles ${target} SOURCES)
@@ -531,10 +518,7 @@ function(target_find_dependencies target)
         find_package(${package_name} REQUIRED ${find_package_args})
       endif()
 
-      # Append to target property
-      set_or_append_target_property(
-        ${target} "PROJECT_OPTIONS_${type}_DEPENDENCIES" "${package_name}"
-      )
+      set_property(TARGET ${target} APPEND PROPERTY "PROJECT_OPTIONS_${type}_DEPENDENCIES" "${package_name}")
     endif()
   endmacro()
 

--- a/tests/minimal/CMakeLists.txt
+++ b/tests/minimal/CMakeLists.txt
@@ -93,11 +93,13 @@ project_options(
 )
 target_compile_features(project_options INTERFACE cxx_std_20)
 
-find_package(Microsoft.GSL CONFIG REQUIRED)
-find_package(fmt CONFIG REQUIRED)
-
 add_executable(example)
 target_sources(example PRIVATE main.cpp)
 target_include_directories(example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(example PRIVATE project_options project_warnings)
+target_find_dependencies(example
+  PUBLIC_CONFIG
+  Microsoft.GSL
+  fmt
+)
 target_link_system_libraries(example PRIVATE Microsoft.GSL::GSL fmt::fmt-header-only)

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -95,12 +95,12 @@ project_options(
 add_executable(main ./src/main/main.cpp)
 target_link_libraries(main PRIVATE myproj_project_options myproj_project_warnings)
 
-## dependencies
-set(DEPENDENCIES_CONFIGURED fmt Eigen3 docopt)
-
-foreach(DEPENDENCY ${DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
+target_find_dependencies(main
+  PUBLIC
+    PACKAGE fmt CONFIG
+    PACKAGE Eigen3 CONFIG
+    PACAKGE docopt CONFIG
+)
 
 target_link_system_libraries(main PRIVATE fmt::fmt Eigen3::Eigen)
 


### PR DESCRIPTION
Extend `target_find_dependencies` to support a more complex syntax:

```cmake
target_find_dependencies(<target_name>
  [ # the old simple mode
    <INTERFACE|PUBLIC|PRIVATE|INTERFACE_CONFIG|PUBLIC_CONFIG|PRIVATE_CONFIG>
    [dependency1...]
  ]...

  [ # the new complex mode
    <INTERFACE|PUBLIC|PRIVATE|INTERFACE_CONFIG|PUBLIC_CONFIG|PRIVATE_CONFIG>
    [PACKAGE <dependency_name> [find_package() argument1...]]...
  ]...
)
```

This allows users to custom how the package is `find_package`-ed:

```cmake
target_find_dependencies(target
  PUBLIC
    PACKAGE Qt6 COMPONENTS Widgets
    PACKAGE fmt CONFIG

  PUBLIC_CONFIG
    range-v3
)
```

Fix #251 