### PR TITLE
fix: fix Hardening options and LTO for multi-configuration generators

### DIFF
--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -44,9 +44,7 @@ function(
         list(APPEND HARDENING_COMPILE_OPTIONS -Wstringop-overflow=4 -Wformat-overflow=2)
       endif()
 
-      if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        target_compile_definitions(${_project_name} INTERFACE _FORTIFY_SOURCE=3)
-      endif()
+      target_compile_definitions(${_project_name} INTERFACE $<$<CONFIG:Release,RelWithDebInfo>:DEBUG_FORTIFY_SOURCE=3>)
     endif()
 
     if(${ENABLE_ELF_PROTECTION})
@@ -64,9 +62,7 @@ function(
       list(APPEND HARDENING_LINK_OPTIONS /guard:cf)
     endif()
 
-    if(${ENABLE_STACK_PROTECTION} AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-      list(APPEND HARDENING_COMPILE_OPTIONS /RTC1)
-    endif()
+    list(APPEND HARDENING_COMPILE_OPTIONS $<$<CONFIG:Debug>:/RTC1>)
 
     if(${ENABLE_OVERFLOW_PROTECTION})
       list(APPEND HARDENING_COMPILE_OPTIONS /sdl)

--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -44,7 +44,7 @@ function(
         list(APPEND HARDENING_COMPILE_OPTIONS -Wstringop-overflow=4 -Wformat-overflow=2)
       endif()
 
-      target_compile_definitions(${_project_name} INTERFACE $<$<CONFIG:Release,RelWithDebInfo>:DEBUG_FORTIFY_SOURCE=3>)
+      target_compile_definitions(${_project_name} INTERFACE $<$<CONFIG:Release,RelWithDebInfo>:_FORTIFY_SOURCE=3>)
     endif()
 
     if(${ENABLE_ELF_PROTECTION})

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.24)
+# 3.24 is required to make CheckIPOSupported prefer to honor the calling project's flags, see https://cmake.org/cmake/help/latest/policy/CMP0138.html
 # 3.20 is required by the windows toolchain and cmake_path. It also has a more reliable building functionality.
 # 3.18 required by package_project and interprocedural optimization. It also has a more reliable building functionality (no errors during the linking stage).
 

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -1,13 +1,14 @@
-cmake_minimum_required(VERSION 3.24)
-# 3.24 is required to make CheckIPOSupported prefer to honor the calling project's flags, see https://cmake.org/cmake/help/latest/policy/CMP0138.html
+cmake_minimum_required(VERSION 3.20)
 # 3.20 is required by the windows toolchain and cmake_path. It also has a more reliable building functionality.
 # 3.18 required by package_project and interprocedural optimization. It also has a more reliable building functionality (no errors during the linking stage).
 
 include_guard()
 
-# fix DOWNLOAD_EXTRACT_TIMESTAMP warning in FetchContent
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  # fix DOWNLOAD_EXTRACT_TIMESTAMP warning in FetchContent
   cmake_policy(SET CMP0135 NEW)
+  # make CheckIPOSupported prefer to honor the calling project's flags
+  cmake_policy(SET CMP0138 NEW)
 endif()
 
 # only useable here

--- a/src/Optimization.cmake
+++ b/src/Optimization.cmake
@@ -2,25 +2,25 @@ include_guard()
 
 # Enable Interprocedural Optimization (Link Time Optimization, LTO) in the release build
 macro(enable_interprocedural_optimization _project_name)
-  if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    include(CheckIPOSupported)
-    check_ipo_supported(RESULT result OUTPUT output)
-    is_mingw(_is_mingw)
-    if(result AND NOT ${_is_mingw})
-      # If a static library of this project is used in another project that does not have `CMAKE_INTERPROCEDURAL_OPTIMIZATION` enabled, a linker error might happen.
-      # TODO set this option in `package_project` function.
-      message(
-        STATUS
-          "Interprocedural optimization is enabled. In other projects, linking with the compiled libraries of this project might require `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)`"
-      )
-      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-      set_target_properties(${_project_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
-    else()
-      message(
-        WARNING
-          "Interprocedural Optimization is not supported. Not using it. Here is the error log: ${output}"
-      )
-    endif()
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT result OUTPUT output)
+  is_mingw(_is_mingw)
+  if(result AND NOT ${_is_mingw})
+    # If a static library of this project is used in another project that does not have `CMAKE_INTERPROCEDURAL_OPTIMIZATION` enabled, a linker error might happen.
+    # TODO set this option in `package_project` function.
+    message(
+      STATUS
+        "Interprocedural optimization is enabled. In other projects, linking with the compiled libraries of this project might require `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)`"
+    )
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
+    set_target_properties(${_project_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+    set_target_properties(${_project_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
+  else()
+    message(
+      WARNING
+        "Interprocedural Optimization is not supported. Not using it. Here is the error log: ${output}"
+    )
   endif()
 endmacro()
 


### PR DESCRIPTION
fix #259 by using generator expressions and `CMAKE_INTERPROCEDURAL_OPTIMIZATION_<CONFIG>`.