### PR TITLE
fix(MSVC): Don't enforce /Zi if POLICY CMP0141 is available

### DIFF
--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -11,6 +11,11 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0138 NEW)
 endif()
 
+if(POLICY CMP0141)
+  # MSVC debug information format flags are selected by an abstraction.
+  cmake_policy(SET CMP0141 NEW)
+endif()
+
 # only useable here
 set(ProjectOptions_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/src/Sanitizers.cmake
+++ b/src/Sanitizers.cmake
@@ -86,8 +86,19 @@ function(
               "Using MSVC sanitizers requires setting the MSVC environment before building the project. Please manually open the MSVC command prompt and rebuild the project."
           )
         endif()
+        if(POLICY CMP0141)
+          if("${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT}" STREQUAL ""
+             OR "${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT}" STREQUAL "EditAndContinue"
+           )
+            set_target_properties(
+              ${_project_name} PROPERTIES MSVC_DEBUG_INFORMATION_FORMAT ProgramDatabase
+            )
+          endif()
+        else()
+          target_compile_options(${_project_name} INTERFACE /Zi)
+        endif()
         target_compile_options(
-          ${_project_name} INTERFACE /fsanitize=${LIST_OF_SANITIZERS} /Zi /INCREMENTAL:NO
+          ${_project_name} INTERFACE /fsanitize=${LIST_OF_SANITIZERS} /INCREMENTAL:NO
         )
         target_link_options(${_project_name} INTERFACE /INCREMENTAL:NO)
       endif()


### PR DESCRIPTION
With the current implementation if CMAKE_MSVC_DEBUG_INFORMATION_FORMAT is set, it won't be respected as the /Zi flag set on enable_sanitizers will always override it, just skip setting it if POLICY CMP0141 is available, if the user has set CMAKE_MSVC_DEBUG_INFORMATION_FORMAT to EditAndContinue, than only in that case override it.

Fixes #262 