### PR TITLE
fix: Enable policy 137 for check_ipo_supported()

### DIFF
--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -8,6 +8,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   # fix DOWNLOAD_EXTRACT_TIMESTAMP warning in FetchContent
   cmake_policy(SET CMP0135 NEW)
   # make CheckIPOSupported prefer to honor the calling project's flags
+  # this fixes check_ipo_supported() to find clang-scan-deps correctly
+  cmake_policy(SET CMP0137 NEW)
   cmake_policy(SET CMP0138 NEW)
 endif()
 


### PR DESCRIPTION
set [`CMP0137`](https://cmake.org/cmake/help/latest/policy/CMP0137.html) to `NEW` if cmake >= 3.24.

Fixes #267.