### PR TITLE
fix: undef _FORTIFY_SOURCE before setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,6 @@ jobs:
           - os: "windows-2022"
             compiler: "msvc"
             vcvarsall: false
-          - os: "macos-11"
-            compiler: "gcc"
-            cmake: true
-            vcvarsall: true
-          - os: "macos-13"
-            compiler: "gcc"
-            cmake: true
-            vcvarsall: true
         exclude:
           # fails with an internal error
           - os: "macos-12"

--- a/src/Hardening.cmake
+++ b/src/Hardening.cmake
@@ -44,7 +44,7 @@ function(
         list(APPEND HARDENING_COMPILE_OPTIONS -Wstringop-overflow=4 -Wformat-overflow=2)
       endif()
 
-      target_compile_definitions(${_project_name} INTERFACE $<$<CONFIG:Release,RelWithDebInfo>:_FORTIFY_SOURCE=3>)
+      target_compile_options(${_project_name} INTERFACE $<$<CONFIG:Release,RelWithDebInfo>:-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3>)
     endif()
 
     if(${ENABLE_ELF_PROTECTION})

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -88,6 +88,10 @@ project_options(
   # CLANG_WARNINGS "-Weverything"
   LINKER
   "${LINKER}"
+
+  # Test if _FORTIFY_SOURCE is defined only once when ENABLE_OVERFLOW_PROTECTION
+  ENABLE_OVERFLOW_PROTECTION
+  CLANG_TIDY_EXTRA_ARGUMENTS "-warnings-as-errors=clang-diagnostic-macro-redefined"
 )
 # NOTE: project_options and project_warnings are defined inside project_options
 


### PR DESCRIPTION
Build failed on [(macos-12, clang-15, release, developer_mode (warnings_as_errors))](https://github.com/FeignClaims/cpp_conan_template/actions/runs/10350621313/job/28647441558#step:8:198) because of

```txt
error: '_FORTIFY_SOURCE' macro redefined [clang-diagnostic-macro-redefined,-warnings-as-errors]
```

After some research, I noticed both [this guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C%2B%2B.md) and [firefox](https://searchfox.org/mozilla-central/source/build/moz.configure/toolchain.configure#2898-2903) recommend/use `-U_FORTIFY_SOURCE` before `-D_FORTIFY_SOURCE=3` to avoid this problem, So I suggest to fix this issue in this way.