### PR TITLE
fix: remove C++/C 23 until officially released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,5 @@ jobs:
 
       - name: Lint
         run: |
-          pipx install cmakelint
-          pipx install --include-deps cmake-format
+          pipx install cmakelang[YAML]
           task lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - windows-2022
           - ubuntu-22.04
           - macos-13
-          - macos-14
+          # - macos-14
         compiler:
           - llvm
           - gcc
@@ -61,7 +61,7 @@ jobs:
         with:
           compiler: ${{ matrix.compiler }}
           vcvarsall: ${{ contains(matrix.os, 'windows') && matrix.vcvarsall }}
-          cmake: ${{ !contains(matrix.os, 'macos-14') }}
+          cmake: true
           ninja: true
           vcpkg: true
           conan: 2.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,11 @@ jobs:
         compiler:
           - llvm
           - gcc
-        cmake:
-          - true
         vcvarsall:
           - true
         include:
           - os: "windows-2022"
             compiler: "msvc"
-            cmake: true
             vcvarsall: true
           - os: "windows-2022"
             compiler: "msvc"
@@ -55,7 +52,7 @@ jobs:
             ${{ env.XDG_CACHE_HOME }}/vcpkg/archives
             ${{ env.LOCALAPPDATA }}\vcpkg\archives
             ${{ env.APPDATA }}\vcpkg\archives
-          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ env.BUILD_TYPE }}-${{ hashFiles('**/CMakeLists.txt', './vcpkg.json')}}-${{ matrix.cmake }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ env.BUILD_TYPE }}-${{ hashFiles('**/CMakeLists.txt', './vcpkg.json')}}
           restore-keys: |
             ${{ runner.os }}-${{ env.BUILD_TYPE }}-
 
@@ -64,7 +61,7 @@ jobs:
         with:
           compiler: ${{ matrix.compiler }}
           vcvarsall: ${{ contains(matrix.os, 'windows') && matrix.vcvarsall }}
-          cmake: ${{ matrix.cmake }}
+          cmake: ${{ !contains(matrix.os, 'macos-14') }}
           ninja: true
           vcpkg: true
           conan: 2.6.0

--- a/src/Standards.cmake
+++ b/src/Standards.cmake
@@ -22,7 +22,7 @@ macro(set_standards)
     _set_language_standard(
       CXX_LATEST_STANDARD
       CXX
-      23
+      # 23
       20
       17
       14
@@ -39,7 +39,7 @@ macro(set_standards)
     _set_language_standard(
       C_LATEST_STANDARD
       C
-      23
+      # 23
       20
       17
       11

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -17,17 +17,6 @@ if(FEATURE_TESTS)
   )
 endif()
 
-set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "ENABLE_INTERPROCEDURAL_OPTIMIZATION")
-if(APPLE)
-  detect_macos_version(apple_version)
-  if(apple_version VERSION_GREATER_EQUAL 13)
-    # workaround for linkage error as described in https://github.com/Homebrew/homebrew-core/issues/145991
-    # although fixed, this problem still exists in github actions
-    add_link_options(-Wl,-ld_classic)
-    set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "")
-  endif()
-endif()
-
 # Initialize project_options
 project_options(
   ENABLE_CACHE

--- a/tests/myproj/CMakeLists.txt
+++ b/tests/myproj/CMakeLists.txt
@@ -49,17 +49,6 @@ if(NOT MSVC)
   #message(STATUS "Detect Linker: ${LINKER}")
 endif()
 
-set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "ENABLE_INTERPROCEDURAL_OPTIMIZATION")
-if(APPLE)
-  detect_macos_version(apple_version)
-  if(apple_version VERSION_GREATER_EQUAL 13)
-    # workaround for linkage error as described in https://github.com/Homebrew/homebrew-core/issues/145991
-    # although fixed, this problem still exists in github actions
-    add_link_options(-Wl,-ld_classic)
-    set(ENABLE_INTERPROCEDURAL_OPTIMIZATION "")
-  endif()
-endif()
-
 # Initialize project_options
 # uncomment the options to enable them
 project_options(


### PR DESCRIPTION
Some tools in different platforms do not support C++ 23 (e.g. gcc on MacOS)