### PR TITLE
chore: remove redundant [skip ci] check

### DIFF
--- a/.github/workflows/ci.cross.arm.yml
+++ b/.github/workflows/ci.cross.arm.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   Test:
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.cross.mingw.yml
+++ b/.github/workflows/ci.cross.mingw.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   Test:
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.emscripten.yml
+++ b/.github/workflows/ci.emscripten.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   Test:
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   Test:
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Skipping workflow runs is now supported by default (see [Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs)).