### PR TITLE
fix: correct message level for cppcheck fallback standard

### DIFF
--- a/src/StaticAnalyzers.cmake
+++ b/src/StaticAnalyzers.cmake
@@ -42,7 +42,7 @@ macro(enable_cppcheck CPPCHECK_OPTIONS)
         set(CMAKE_CXX_CPPCHECK ${CMAKE_CXX_CPPCHECK} --std=c++${CMAKE_CXX_STANDARD})
       else()
         message(
-          ${WARNING_MESSAGE}
+          STATUS
           "cppcheck doesn't support specified C++ standard ${CMAKE_CXX_STANDARD}. Using the cppcheck default C++ standard version."
         )
       endif()
@@ -54,8 +54,8 @@ macro(enable_cppcheck CPPCHECK_OPTIONS)
       elseif(CMAKE_C_STANDARD MATCHES [[99|11]])
         set(CMAKE_C_CPPCHECK ${CMAKE_C_CPPCHECK} --std=c${CMAKE_C_STANDARD})
       else()
-        message(${WARNING_MESSAGE}
-                "cppcheck doesn't support C ${CMAKE_C_STANDARD} standard. Using the cppcheck default"
+        message(STATUS
+                "cppcheck doesn't support C ${CMAKE_C_STANDARD} standard. Using the cppcheck default C standard version"
         )
       endif()
     endif()


### PR DESCRIPTION
We provide no way to explicitly and separately (without changing `CMAKE_<LANG>_STANDARD`) specify what standard cppcheck should use. Therefore, when cppcheck fallbacking to use the default standard, the corresponding cmake message should be `STATUS` instead of `${WARNING_MESSAGE}` which fails the compilation when `WARNINGS_AS_ERRORS`.